### PR TITLE
Change moveit_task_constructor in moveit2_tutorials.repos to point to humble

### DIFF
--- a/moveit2/Dockerfile
+++ b/moveit2/Dockerfile
@@ -84,8 +84,12 @@ RUN python3 -m pip install -U \
 # Get the MoveIt2 source code
 WORKDIR ${HOME_DIR}
 RUN sudo git clone https://github.com/ros-planning/moveit2.git -b ${ROSDISTRO} moveit2/src
-RUN cd ${MOVEIT2_DIR}/src \
-  && sudo git clone https://github.com/ros-planning/moveit2_tutorials.git -b ${ROSDISTRO}
+
+# Move pre-downloaded MoveIt2 tutorials into the source tree
+COPY --chown=${USERNAME}:${USERNAME} moveit2_tutorials ${MOVEIT2_DIR}/src/moveit2_tutorials
+# Original way of getting tutorials, but it's slow when doing development
+#RUN cd ${MOVEIT2_DIR}/src \
+#  && sudo git clone https://github.com/ros-planning/moveit2_tutorials.git -b ${ROSDISTRO}
 
 # Update the ownership of the source files (had to use sudo above to work around
 # a possible inherited 'insteadof' from the host that forces use of ssh

--- a/moveit2/moveit2_tutorials.repos
+++ b/moveit2/moveit2_tutorials.repos
@@ -2,7 +2,7 @@ repositories:
   moveit_task_constructor:
     type: git
     url: https://github.com/ros-planning/moveit_task_constructor.git
-    version: ros2
+    version: humble
   moveit_visual_tools:
     type: git
     url: https://github.com/ros-planning/moveit_visual_tools

--- a/space_robots/Dockerfile
+++ b/space_robots/Dockerfile
@@ -62,10 +62,22 @@ RUN sudo apt-get update -y && sudo apt-get install -y python3-rosinstall-generat
 RUN mkdir -p ${DEMO_DIR}/src
 WORKDIR ${DEMO_DIR}
 
+# Install libmongoc for development
+#RUN wget https://github.com/mongodb/mongo-c-driver/releases/download/1.2.1/mongo-c-driver-1.2.1.tar.gz
+#RUN tar -xzf mongo-c-driver-1.2.1.tar.gz
+#RUN cd mongo-c-driver-1.2.1 && ./configure && make && sudo make install
+RUN sudo apt install libmongoc-dev -y
+
+# Compile mongo cxx driver https://mongocxx.org/mongocxx-v3/installation/linux/
+RUN sudo apt install libssl-dev build-essential devscripts debian-keyring fakeroot debhelper cmake libboost-dev libsasl2-dev libicu-dev libzstd-dev doxygen -y
+RUN wget https://github.com/mongodb/mongo-cxx-driver/releases/download/r3.6.7/mongo-cxx-driver-r3.6.7.tar.gz
+RUN tar -xzf mongo-cxx-driver-r3.6.7.tar.gz
+RUN cd mongo-cxx-driver-r3.6.7/build && cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local && sudo cmake --build . --target EP_mnmlstc_core && cmake --build . && sudo cmake --build . --target install
+
 # Get the source for the dependencies
 # RUN vcs import src < /tmp/demo_generated_pkgs.repos
 COPY --chown=${USERNAME}:${USERNAME} demo_manual_pkgs.repos /tmp/
-RUN vcs import src < /tmp/demo_manual_pkgs.repos
+RUN vcs import src < /tmp/demo_manual_pkgs.repos && /bin/bash -c 'source "${SPACEROS_DIR}/install/setup.bash"' \
 
 RUN sudo apt-get update -y \
 && /bin/bash -c 'source "${SPACEROS_DIR}/install/setup.bash"' \

--- a/space_robots/demo_manual_pkgs.repos
+++ b/space_robots/demo_manual_pkgs.repos
@@ -23,3 +23,7 @@ repositories:
     type: git
     url: https://github.com/space-ros/simulation.git
     version: main
+  ros-humble-warehouse-ros-mongo:
+    type: git
+    url: https://github.com/ros-planning/warehouse_ros_mongo.git
+    version: ros2


### PR DESCRIPTION
moveit2 currently fails to build because of moveit_task_constructor pointing to `trajectory` instead of `trajectory_`, as required by the version of moveit2_tutorials we are pointing to.  
This is discussed in this issue: https://github.com/ros-planning/moveit2/issues/1953 and this pr: https://github.com/ros-planning/moveit_task_constructor/pull/426  

Changing the moveit_task_constructor branch to humble fixes the issue. 