### PR TITLE
Change moveit_task_constructor in moveit2_tutorials.repos to point to humble

### DIFF
--- a/moveit2/moveit2_tutorials.repos
+++ b/moveit2/moveit2_tutorials.repos
@@ -2,7 +2,7 @@ repositories:
   moveit_task_constructor:
     type: git
     url: https://github.com/ros-planning/moveit_task_constructor.git
-    version: ros2
+    version: humble
   moveit_visual_tools:
     type: git
     url: https://github.com/ros-planning/moveit_visual_tools


### PR DESCRIPTION
Repost of #48, my apologies.

moveit2 currently fails to build because of moveit_task_constructor pointing to trajectory instead of trajectory_, as required by the version of moveit2_tutorials we are pointing to.
This is discussed in this issue: https://github.com/ros-planning/moveit2/issues/1953 and this pr: https://github.com/ros-planning/moveit_task_constructor/pull/426

Changing the moveit_task_constructor branch to humble fixes the issue.