### PR TITLE
Fix the MoveIt2 build for Space ROS on Ubuntu Jammy.

### DIFF
--- a/moveit2/moveit2_tutorials.repos
+++ b/moveit2/moveit2_tutorials.repos
@@ -2,7 +2,7 @@ repositories:
   moveit_task_constructor:
     type: git
     url: https://github.com/ros-planning/moveit_task_constructor.git
-    version: ros2
+    version: humble
   moveit_visual_tools:
     type: git
     url: https://github.com/ros-planning/moveit_visual_tools


### PR DESCRIPTION
The moveit_task_constructor package now has a humble branch that is required because of some name changes.

Fixes: https://github.com/space-ros/space-ros/issues/32