### PR TITLE
Add build actions on pull request and on demand

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -15,6 +15,15 @@ jobs:
         uses: actions/checkout@v2
       - name: Set up buildx
         uses: docker/setup-buildx-action@v1
+      - name: Build moveit2 image
+        uses: docker/build-push-action@v2
+        with:
+          context: moveit2
+          push: false
+          tags: openrobotics/moveit2
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          no-cache: true
       - name: Build space robots demo image
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,8 +1,10 @@
 name: Docker build
 on:
+  workflow_dispatch:
   push:
     branches: ['main']
   pull_request:
+    branches: ['main']
   schedule:
     - cron: '0 2 * * *'
 jobs:


### PR DESCRIPTION
Adds build actions: on 'pull_request'  will automatically run a build each time a PR is opened,  and on 'workflow_dispatch' which will enable a "Run workflow" button on the Actions tab.

Addresses parts of #55 