### PR TITLE
Use Docker cache mounts for Apt lists

### DIFF
--- a/moveit2/Dockerfile
+++ b/moveit2/Dockerfile
@@ -46,12 +46,20 @@ RUN mkdir ${SPACEROS_DIR}/src \
 ENV MOVEIT2_DIR=${HOME_DIR}/moveit2
 
 # Make sure the latest versions of packages are installed
-RUN sudo apt-get update
-RUN sudo apt-get dist-upgrade -y
+# Using Docker BuildKit cache mounts for /var/cache/apt and /var/lib/apt ensures that
+# the cache won't make it into the built image but will be maintained between steps.
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  --mount=type=cache,target=/var/lib/apt,sharing=locked \
+  sudo apt-get update
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  --mount=type=cache,target=/var/lib/apt,sharing=locked \
+  sudo apt-get dist-upgrade -y
 RUN rosdep update
 
 # Install the various build and test tools
-RUN sudo apt install -y \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  --mount=type=cache,target=/var/lib/apt,sharing=locked \
+  sudo apt install -y \
   build-essential \
   clang-format \
   cmake \
@@ -92,7 +100,9 @@ RUN cd ${MOVEIT2_DIR}/src \
 RUN sudo chown -R ${USERNAME}:${USERNAME} ${MOVEIT2_DIR}
 
 # Get rosinstall_generator
-RUN sudo apt-get update -y && sudo apt-get install -y python3-rosinstall-generator
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  --mount=type=cache,target=/var/lib/apt,sharing=locked \
+  sudo apt-get update -y && sudo apt-get install -y python3-rosinstall-generator
 
 # Generate repos file for moveit2 dependencies, excluding packages from Space ROS core.
 COPY --chown=${USERNAME}:${USERNAME} moveit2-pkgs.txt /tmp/
@@ -116,7 +126,9 @@ RUN vcs import src < /tmp/moveit2_tutorials.repos
 RUN sudo chown -R ${USERNAME}:${USERNAME} ${MOVEIT2_DIR}
 
 # Install system dependencies
-RUN /bin/bash -c 'source ${SPACEROS_DIR}/install/setup.bash' \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  --mount=type=cache,target=/var/lib/apt,sharing=locked \
+  /bin/bash -c 'source ${SPACEROS_DIR}/install/setup.bash' \
  && rosdep install --from-paths ../spaceros/src src --ignore-src --rosdistro ${ROSDISTRO} -r -y --skip-keys "console_bridge generate_parameter_library fastcdr fastrtps rti-connext-dds-5.3.1 urdfdom_headers rmw_connextdds ros_testing rmw_connextdds rmw_fastrtps_cpp rmw_fastrtps_dynamic_cpp composition demo_nodes_py lifecycle rosidl_typesupport_fastrtps_cpp rosidl_typesupport_fastrtps_c ikos diagnostic_aggregator diagnostic_updater joy qt_gui rqt_gui rqt_gui_py"
 
 # Apply a patch to octomap_msgs to work around a build issue
@@ -128,7 +140,9 @@ RUN /bin/bash -c 'source ${SPACEROS_DIR}/install/setup.bash \
   && colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON --event-handlers desktop_notification- status-'
 
 # Add a couple sample GUI apps for testing
-RUN sudo apt-get install -y \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  --mount=type=cache,target=/var/lib/apt,sharing=locked \
+  sudo apt-get install -y \
   firefox \
   glmark2 \
   libcanberra-gtk3-0 \

--- a/renode_rcc/Dockerfile
+++ b/renode_rcc/Dockerfile
@@ -2,7 +2,11 @@ FROM ubuntu:20.04
 WORKDIR /root
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN apt-get update -y && \
+# Using Docker BuildKit cache mounts for /var/cache/apt and /var/lib/apt ensures that
+# the cache won't make it into the built image but will be maintained between steps.
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update -y && \
     apt-get install -y automake \
     autoconf \
     ca-certificates \
@@ -18,7 +22,9 @@ RUN apt-get update -y && \
 ARG RENODE_VERSION=1.13.0
 
 USER root
-RUN wget https://github.com/renode/renode/releases/download/v${RENODE_VERSION}/renode_${RENODE_VERSION}_amd64.deb && \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    wget https://github.com/renode/renode/releases/download/v${RENODE_VERSION}/renode_${RENODE_VERSION}_amd64.deb && \
     apt-get update && \
     apt-get install -y --no-install-recommends ./renode_${RENODE_VERSION}_amd64.deb python3-dev && \
     rm ./renode_${RENODE_VERSION}_amd64.deb

--- a/rtems/Dockerfile
+++ b/rtems/Dockerfile
@@ -2,7 +2,11 @@ FROM ubuntu:20.04
 WORKDIR /root
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN apt-get update \
+# Using Docker BuildKit cache mounts for /var/cache/apt and /var/lib/apt ensures that
+# the cache won't make it into the built image but will be maintained between steps.
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update \
     && apt-get install -y \
         apt-utils \
         bison \

--- a/space_robots/Dockerfile
+++ b/space_robots/Dockerfile
@@ -44,7 +44,11 @@ ENV GZ_VERSION fortress
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Get rosinstall_generator
-RUN sudo apt-get update -y && sudo apt-get install -y python3-rosinstall-generator
+# Using Docker BuildKit cache mounts for /var/cache/apt and /var/lib/apt ensures that
+# the cache won't make it into the built image but will be maintained between steps.
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  --mount=type=cache,target=/var/lib/apt,sharing=locked \
+  sudo apt-get update -y && sudo apt-get install -y python3-rosinstall-generator
 
 # TODO(anyone): remove demo-pkgs.txt, no packages left after exclusions
 # Generate repos file for demo dependencies, excluding packages from Space ROS core.
@@ -64,10 +68,14 @@ WORKDIR ${DEMO_DIR}
 
 
 # Install libmongoc for development
-RUN sudo apt install libmongoc-dev -y
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  --mount=type=cache,target=/var/lib/apt,sharing=locked \
+  sudo apt-get install libmongoc-dev -y
 
 # Compile mongo cxx driver https://mongocxx.org/mongocxx-v3/installation/linux/
-RUN sudo apt install libssl-dev build-essential devscripts debian-keyring fakeroot debhelper cmake libboost-dev libsasl2-dev libicu-dev libzstd-dev doxygen -y
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  --mount=type=cache,target=/var/lib/apt,sharing=locked \
+  sudo apt-get install libssl-dev build-essential devscripts debian-keyring fakeroot debhelper cmake libboost-dev libsasl2-dev libicu-dev libzstd-dev doxygen -y
 RUN wget https://github.com/mongodb/mongo-cxx-driver/releases/download/r3.6.7/mongo-cxx-driver-r3.6.7.tar.gz
 RUN tar -xzf mongo-cxx-driver-r3.6.7.tar.gz
 RUN cd mongo-cxx-driver-r3.6.7/build && cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local && sudo cmake --build . --target EP_mnmlstc_core && cmake --build . && sudo cmake --build . --target install
@@ -77,7 +85,9 @@ RUN cd mongo-cxx-driver-r3.6.7/build && cmake .. -DCMAKE_BUILD_TYPE=Release -DCM
 COPY --chown=${USERNAME}:${USERNAME} demo_manual_pkgs.repos /tmp/
 RUN vcs import src < /tmp/demo_manual_pkgs.repos && /bin/bash -c 'source "${SPACEROS_DIR}/install/setup.bash"' 
 
-RUN sudo apt-get update -y \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  --mount=type=cache,target=/var/lib/apt,sharing=locked \
+  sudo apt-get update -y \
 && /bin/bash -c 'source "${SPACEROS_DIR}/install/setup.bash"' \
 && /bin/bash -c 'source "${MOVEIT2_DIR}/install/setup.bash"' \
 && rosdep install --from-paths src --ignore-src -r -y --rosdistro ${ROSDISTRO}

--- a/zynq_rtems/Dockerfile
+++ b/zynq_rtems/Dockerfile
@@ -2,7 +2,11 @@ FROM ubuntu:20.04
 WORKDIR /root
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN apt-get update \
+# Using Docker BuildKit cache mounts for /var/cache/apt and /var/lib/apt ensures that
+# the cache won't make it into the built image but will be maintained between steps.
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update \
     && apt-get install -y \
         apt-utils \
         bison \


### PR DESCRIPTION
I've added

```
--mount=type=cache,target=/var/cache/apt,sharing=locked \
--mount=type=cache,target=/var/lib/apt,sharing=locked \
```

in front of every operation that modifies the Apt lists. This ensures that the Apt lists will not end up in the layers and in the final image, while preserving the lists between operations so it doesn't slow down the build.