### PR TITLE
Update moveit_task_constructor branch back to *humble*

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -32,7 +32,7 @@ jobs:
           tags: openrobotics/moveit2:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          no-cache: true
+          no-cache: false
       - name: Build space robots demo image
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -33,12 +33,8 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           no-cache: false
+          outputs: type=docker,dest=/tmp/moveit2.tar
       - name: Build space robots demo image
-        uses: docker/build-push-action@v2
-        with:
-          context: space_robots
-          push: false
-          tags: space_robots
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          no-cache: true
+        run: |
+          docker images
+          cd space_robots && build.sh

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -36,5 +36,6 @@ jobs:
           outputs: type=docker,dest=/tmp/moveit2.tar
       - name: Build space robots demo image
         run: |
+          docker load --input /tmp/moveit2.tar
           docker images
-          cd space_robots && build.sh
+          cd space_robots && ./build.sh

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           context: moveit2
           push: false
-          tags: openrobotics/moveit2
+          tags: openrobotics/moveit2:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
           no-cache: true

--- a/moveit2/moveit2_tutorials.repos
+++ b/moveit2/moveit2_tutorials.repos
@@ -2,7 +2,7 @@ repositories:
   moveit_task_constructor:
     type: git
     url: https://github.com/ros-planning/moveit_task_constructor.git
-    version: ros2
+    version: humble
   moveit_visual_tools:
     type: git
     url: https://github.com/ros-planning/moveit_visual_tools


### PR DESCRIPTION
Attempt to fix #64. The upstream branch was updated back to `humble`. 