### PR TITLE
Add pipefail to space_robots build so that it fails on error

### DIFF
--- a/moveit2/build.sh
+++ b/moveit2/build.sh
@@ -7,6 +7,9 @@ TAG=latest
 VCS_REF=""
 VERSION=preview
 
+# Exit script with failure if build fails
+set -eo pipefail
+
 echo ""
 echo "##### Building Space ROS/MoveIt2 Docker Image #####"
 echo ""

--- a/space_robots/build.sh
+++ b/space_robots/build.sh
@@ -7,6 +7,9 @@ TAG=latest
 VCS_REF=""
 VERSION=preview
 
+# Exit script with failure if build fails
+set -eo pipefail
+
 echo ""
 echo "##### Building Space ROS Demo Docker Image #####"
 echo ""

--- a/spaceros/build.sh
+++ b/spaceros/build.sh
@@ -3,6 +3,9 @@
 VCS_REF="$(git rev-parse HEAD)"
 VERSION=preview
 
+# Exit script with failure if build fails
+set -eo pipefail
+
 echo ""
 echo "##### Building Space ROS Docker Image #####"
 echo ""


### PR DESCRIPTION
Adding `set -eo pipefail` to the space_robots workflow to fix #75 