### PR TITLE
Add markdown-link-check workflow

### DIFF
--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -1,0 +1,15 @@
+name: Markdown Link Check
+on:
+  workflow_dispatch:
+  push:
+    branches: ['main']
+  pull_request:
+    branches: ['main']
+  schedule:
+    - cron: '0 2 * * *'
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ Space ROS Docker Image Templates
 See individual template directories for details.
 
 * [moveit2](./moveit2)
-* [moveit2_tutorials](./moveit2_tutorials)
 * [renode_rcc](./renode_rcc)
 * [rtems](./rtems)
 * [space_robots](./space_robots)

--- a/moveit2/README.md
+++ b/moveit2/README.md
@@ -55,7 +55,7 @@ You should see lots of console output and the rviz2 window appear:
 
 ![rviz2 tutorial window](resources/moveit2-rviz-tutorial.png)
 
-You can now following the [MoveIt2 Tutorial documentation](https://moveit.picknik.ai/galactic/doc/tutorials/quickstart_in_rviz/quickstart_in_rviz_tutorial.html).
+You can now following the [MoveIt2 Tutorial documentation](https://moveit.picknik.ai/main/doc/tutorials/quickstart_in_rviz/quickstart_in_rviz_tutorial.html).
 
 ## Running the MoveIt2 Move Group C++ Interface Demo
 

--- a/zynq_rtems/README.md
+++ b/zynq_rtems/README.md
@@ -16,14 +16,14 @@ We selected [RTEMS](https://www.rtems.org/) because it is fully open-source and 
 
 To simplify collecting and compiling dependencies on a wide range of systems, we have created a Docker container that contains everything.
 You will need to install Docker on your system first, for example, using `sudo apt install docker.io`
-Then, run this [script](https://github.com/space-ros/docker/blob/zynq_rtems/zynq_rtems/build_dependencies.sh):
+Then, run this [script](https://github.com/space-ros/docker/blob/main/zynq_rtems/build_dependencies.sh):
 
 ```
 cd /path/to/zynq_rtems
 ./build_dependencies.sh
 ```
 
-This will build the [zynq_rtems Dockerfile](https://github.com/space-ros/docker/blob/zynq_rtems_zenoh_pico/zynq_rtems/Dockerfile), which builds QEMU, a cross-compile toolchain for the ARMv8 processor inside the Zynq SoC, and RTEMS from source in the container.
+This will build the [zynq_rtems Dockerfile](https://github.com/space-ros/docker/blob/main/zynq_rtems/Dockerfile), which builds QEMU, a cross-compile toolchain for the ARMv8 processor inside the Zynq SoC, and RTEMS from source in the container.
 This will typically take at least 10 minutes, and can take much longer if either your network connection or compute resources is limited.
 
 Next, we will use this "container full of dependencies" to compile a sample application.


### PR DESCRIPTION
Add the markdown-link-check workflow in GHA. Fixes #72 

Note that this should fail due to #68, until that is fixed. I'll add a second commit to fix that once this runs and flags the issue.