### PR TITLE
Point users to `space_robots` demo at the end of `moveit2` README (#85)

### DIFF
--- a/moveit2/README.md
+++ b/moveit2/README.md
@@ -68,3 +68,7 @@ ros2 launch moveit2_tutorials move_group.launch.py
 ![rviz2 move group window](resources/moveit2-rviz.png)
 
 Then, you can follow the [Move Group C++ Interface Demo documentation](https://moveit.picknik.ai/humble/doc/examples/move_group_interface/move_group_interface_tutorial.html).
+
+## Running the Space ROS Space Robots Demos
+
+Once you have tested that MoveIt2 works, you are ready to run some of the other [Space ROS space robot demos](../space_robots/README.md).


### PR DESCRIPTION
I was doing some testing with these Docker images to give an official MoveIt maintainer sign-off for working MoveIt2 images.

I was able to run both the MoveIt2 Tutorials RViz example as per the `moveit2` image, and also the Canadarm demo in the `space_robots` image.

Just submitting a few small tweaks based on my trying to follow the instructions, but otherwise 👍🏻 

Closes https://github.com/space-ros/docker/issues/85

---

Quick question -- can I also remove all the `$` from all the README Instructions, like

```
$ ./run.sh
```

because it makes it annoying to copy paste -- I have to manually select the text or remove the first few characters instead of copying the entire line.