### PR TITLE
Don't limit parallel workers in moveit2 build (#77)

### DIFF
--- a/moveit2/Dockerfile
+++ b/moveit2/Dockerfile
@@ -125,7 +125,7 @@ RUN cd src/octomap_msgs && git apply octomap_fix.diff
 
 # Build MoveIt2
 RUN /bin/bash -c 'source ${SPACEROS_DIR}/install/setup.bash \
-  && colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON --event-handlers desktop_notification- status- --parallel-workers 1'
+  && colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON --event-handlers desktop_notification- status-'
 
 # Add a couple sample GUI apps for testing
 RUN sudo apt-get install -y \


### PR DESCRIPTION
Closes #77.

This is a common hack to avoid running out of memory while building a large C++ codebase. However, it's unnecessary in an era where users just need to be educated to configure `zram` on their system.