### PR TITLE
Add vision_msgs to demo deps (#87)

### DIFF
--- a/space_robots/demo_manual_pkgs.repos
+++ b/space_robots/demo_manual_pkgs.repos
@@ -31,4 +31,7 @@ repositories:
     type: git
     url: https://github.com/ros-planning/warehouse_ros_mongo.git
     version: ros2
-    
+  vision_msgs:
+    type: git
+    url: https://github.com/ros-perception/vision_msgs.git
+    version: ros2


### PR DESCRIPTION
This source dependency is missing and failing the build. Closes #87.