### PR TITLE
Fix typos in READMEs (#111).

### DIFF
--- a/moveit2/README.md
+++ b/moveit2/README.md
@@ -55,7 +55,7 @@ You should see lots of console output and the rviz2 window appear:
 
 ![rviz2 tutorial window](resources/moveit2-rviz-tutorial.png)
 
-You can now following the [MoveIt2 Tutorial documentation](https://moveit.picknik.ai/main/doc/tutorials/quickstart_in_rviz/quickstart_in_rviz_tutorial.html).
+You can now follow the [MoveIt2 Tutorial documentation](https://moveit.picknik.ai/main/doc/tutorials/quickstart_in_rviz/quickstart_in_rviz_tutorial.html).
 
 ## Running the MoveIt2 Move Group C++ Interface Demo
 

--- a/space_robots/README.md
+++ b/space_robots/README.md
@@ -29,7 +29,7 @@ Then run:
 ./run.sh
 ```
 
-Depending on the host computer, you might need to remove ```--gpus all``` flag in ```run.sh```, which uses your GPUs.
+Depending on the host computer, you might need to remove the ```--gpus all``` flag in ```run.sh```, which uses your GPUs.
 
 ## Running the Demos
 


### PR DESCRIPTION
Fix two typos (wrong word, missing article).

Filed on behalf of @sea-bass (I'm just the messenger). Authorship information retained.