### PR TITLE
Ensure that cobra is executed during tests (#103).

### DIFF
--- a/spaceros/Earthfile
+++ b/spaceros/Earthfile
@@ -153,7 +153,7 @@ build:
 build-testing:
   FROM +rosdep
   RUN colcon build --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_EXPORT_COMPILE_COMMANDS=ON --no-warn-unused-cli
-  RUN colcon test --retest-until-pass 2 --ctest-args -LE "(ikos|xfail)" --pytest-args -m "not xfail"
+  RUN . install/setup.sh && colcon test --retest-until-pass 2 --ctest-args -LE "(ikos|xfail)" --pytest-args -m "not xfail"
   RUN . install/setup.sh && ros2 run process_sarif make_build_archive
   COPY +vcs-exact/exact.repos install/exact.repos
   SAVE ARTIFACT log/build_results_archives/build_results_*.tar.bz2 AS LOCAL log/build_results_archives/


### PR DESCRIPTION
## Summary
This PR fixes https://github.com/space-ros/docker/issues/103.

Space ROS's main Earthfile's build-testing procedure is invoked in CI to push results of tests and static code analysis. Currently, for all packages cobra-autosar.sarif results are empty. This is because cobra or some dependent executables are not found when colcon test command is invoked.

This PR prefixes the call to colcon test in the Earthfile by a call to source that brings all the necessary tools and dependencies into scope.

Note that re-enabling cobra significantly extends `build-testing` time from 1hr 13 minutes to 1hr 55 minutes on my local machine [^1].

Check the files before and after for comparison:
* [cobra-autosar file prior to fix](https://gist.github.com/xfiderek/46bd91b0c6f65277284ab944d16e82e2)
* [cobra-autosar file after fix](https://gist.github.com/xfiderek/b7c1be5f78ee391ea0284859c0f8c9d0#file-cobra-autosar-after-fix-json)

## Future work
The results on SARIF dashboard are empty anyway, despite the fix. The reason is that `level` and `kind` fields in results have value "unknown" [^2]. It can be an issue either with `process_sarif` package or with `ament_cobra` package. I will investigate that further and raise consecutive issues.

[^1]: Time compared using `time earthly --no-cache +build-testing` command
[^2]: Visualizing the results from `build` folder works, however cobra-autosar file from `processed` folder shows no results on dashboard. After changing `level` and `kind` fields in processed files, violated rules are displayed on dashboard as expected.
