### PR TITLE
Update GA to push image to Docker Hub only on tags (#93).

### DIFF
--- a/.github/workflows/earthly-build.yaml
+++ b/.github/workflows/earthly-build.yaml
@@ -1,7 +1,9 @@
 name: Earthly build
 on:
+  workflow_dispatch:
   push:
     branches: ['main']
+    tags: ['*']
   pull_request:
   schedule:
     - cron: '0 11 * * *'
@@ -45,7 +47,7 @@ jobs:
       - name: Push spaceros image
         env:
           DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_RW_TOKEN }}
-        if: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' }}
+        if: ${{ github.ref_type == 'tag' }}
         run: |
           echo $DOCKER_HUB_TOKEN | docker login --username osrfbot --password-stdin
           cd spaceros


### PR DESCRIPTION
This commit disables pushes of the spaceros docker image up to Docker Hub on the main branch, and it enables pushes on tags. It also enables manually triggering the build job.

This will help ensure that only stable version are pushed to Docker Hub.