### PR TITLE
Fix IKOS tutorial (#138).

### DIFF
--- a/spaceros/Earthfile
+++ b/spaceros/Earthfile
@@ -178,6 +178,7 @@ rosdep:
         ..
   RUN make
   RUN sudo make install
+  ENV PATH="/opt/ikos/bin/:$PATH"
   WORKDIR $SPACEROS_DIR
   RUN sudo rm -rf ikos/
 

--- a/spaceros/README.md
+++ b/spaceros/README.md
@@ -215,24 +215,29 @@ spaceros-user@d10d85c68f0e:~/spaceros$ CC="ikos-scan-cc" CXX="ikos-scan-c++" LD=
 
 ## Generating IKOS Results
 
-To generate JUnit XML files for all of the binaries resulting from the build command in the previous step, you can use **colcon test**, as follows:
+To generate JUnit XML/SARIF files for all of the binaries resulting from the build command in the previous step, you can use **colcon test**, as follows:
 
 ```
-spaceros-user@d10d85c68f0e:~/spaceros$ colcon test --build-base build_ikos --install-base install_ikos
+spaceros-user@d10d85c68f0e:~/spaceros$ colcon test --build-base build_ikos --install-base install_ikos --ctest-args -L "ikos"
 ```
 
 To generate a JUnit XML file for a specific package only, you can add the *--packages-select* option, as follows:
 
 ```
-spaceros-user@d10d85c68f0e:~/spaceros$ colcon test --build-base build_ikos --install-base install_ikos --packages-select rcpputils
+spaceros-user@d10d85c68f0e:~/spaceros$ colcon test --build-base build_ikos --install-base install_ikos --ctest-args -L "ikos" --packages-select rcpputils
 ```
 
-The `colcon test` command runs various tests, including IKOS report generation, which reads the IKOS database generated in the previous analysis step and generates a JUnit XML report file.
+The `colcon test` command with the `-L "ikos"` flag runs IKOS report generation, which reads the IKOS database generated in the previous analysis step and generates a JUnit XML report file.
 After running `colcon test`, you can view the JUnit XML files.
 For example, to view the JUnit XML file for IKOS scan of the rcpputils binaries you can use the following command:
 
 ```
 spaceros-user@d10d85c68f0e:~/spaceros$ more build_ikos/rcpputils/test_results/rcpputils/ikos.xunit.xml
+```
+
+SARIF files are also available in the same path:
+```
+spaceros-user@d10d85c68f0e:~/spaceros$ more build_ikos/rcpputils/test_results/rcpputils/ikos.sarif
 ```
 
 ## Saving build artifacts locally

--- a/spaceros/entrypoint.sh
+++ b/spaceros/entrypoint.sh
@@ -3,4 +3,5 @@ set -e
 
 # Setup the Space ROS environment
 source "${SPACEROS_DIR}/install/setup.bash"
+export IKOS_SCAN_NOTIFIER_FILES="" # make ikos create .ikosbin files for compiled packages
 exec "$@"


### PR DESCRIPTION
This PR addresses https://github.com/space-ros/docker/issues/138, by adjusting the Earthfile, entrypoint.sh, and README.md, so that IKOS tutorial is runnable.