### PR TITLE
Add tags to earthly build workflow to tag releases

### DIFF
--- a/.github/workflows/earthly-build.yaml
+++ b/.github/workflows/earthly-build.yaml
@@ -1,6 +1,11 @@
 name: Earthly build
 on:
   workflow_dispatch:
+    inputs:
+      image-tag:
+        description: 'Image tag for Dockerhub'
+        required: false
+        default: 'latest'
   push:
     branches: ['main']
     tags: ['*']
@@ -51,4 +56,4 @@ jobs:
         run: |
           echo $DOCKER_HUB_TOKEN | docker login --username osrfbot --password-stdin
           cd spaceros
-          earthly --ci --push +image
+          earthly --ci --push +image --tag=$INPUT_IMAGE-TAG

--- a/spaceros/Earthfile
+++ b/spaceros/Earthfile
@@ -200,6 +200,7 @@ build-testing:
 image:
   FROM +rosdep
   ARG VCS_REF
+  ARG tag='latest'
 
   # Specify the docker image metadata
   LABEL org.label-schema.schema-version="1.0"
@@ -216,4 +217,4 @@ image:
   COPY entrypoint.sh /ros_entrypoint.sh
   ENTRYPOINT ["/ros_entrypoint.sh"]
   CMD ["bash"]
-  SAVE IMAGE --push osrf/space-ros:latest
+  SAVE IMAGE --push osrf/space-ros:$tag


### PR DESCRIPTION
Fixes #148 by adding an input image tag to the workflow and Earthfile