### PR TITLE
Auto tag release image (fix #148)

### DIFF
--- a/.github/workflows/earthly-build.yaml
+++ b/.github/workflows/earthly-build.yaml
@@ -51,4 +51,4 @@ jobs:
         run: |
           echo $DOCKER_HUB_TOKEN | docker login --username osrfbot --password-stdin
           cd spaceros
-          earthly --ci --push +image
+          earthly --ci --push +image --tag=${{ github.ref_name }}

--- a/spaceros/Earthfile
+++ b/spaceros/Earthfile
@@ -200,6 +200,7 @@ build-testing:
 image:
   FROM +rosdep
   ARG VCS_REF
+  ARG tag='latest'
 
   # Specify the docker image metadata
   LABEL org.label-schema.schema-version="1.0"
@@ -216,4 +217,4 @@ image:
   COPY entrypoint.sh /ros_entrypoint.sh
   ENTRYPOINT ["/ros_entrypoint.sh"]
   CMD ["bash"]
-  SAVE IMAGE --push osrf/space-ros:latest
+  SAVE IMAGE --push osrf/space-ros:$tag

--- a/spaceros/Earthfile
+++ b/spaceros/Earthfile
@@ -217,4 +217,4 @@ image:
   COPY entrypoint.sh /ros_entrypoint.sh
   ENTRYPOINT ["/ros_entrypoint.sh"]
   CMD ["bash"]
-  SAVE IMAGE --push osrf/space-ros:$tag
+  SAVE IMAGE --push osrf/space-ros:latest osrf/space-ros:$tag


### PR DESCRIPTION
This uses `github.ref_name` as a tag when the image is pushed to Dockerhub, which fixes #148 

The only way I know to test this is to add a tag to the repo and see if it works. However if it does push to Dockerhub, I can't remove the image if it's tagged incorrectly. I'm open to other suggestions how to test it.