### PR TITLE
Pin navigation2 repos and simplify docker build (#142).

### DIFF
--- a/nav2_demo/README.md
+++ b/nav2_demo/README.md
@@ -22,7 +22,7 @@ Start the space_nav2 container and launch the navigation2 nodes:
 
 ```
 ./run.sh
-ros2 launch nav2_bringup navigation_launch.py use_sim_time:=True params_file:=nav2_params.yaml
+ros2 launch space_nav2_bringup navigation_launch.py use_sim_time:=True params_file:=nav2_params.yaml
 ```
 
 ## Terminal 3 - launch localization with map
@@ -30,7 +30,7 @@ ros2 launch nav2_bringup navigation_launch.py use_sim_time:=True params_file:=na
 ```
 docker exec -it osrf_space_nav2_demo bash
 source install/setup.bash
-ros2 launch nav2_bringup localization_launch.py use_sim_time:=True map:=mars_map.yaml
+ros2 launch space_nav2_bringup localization_launch.py use_sim_time:=True map:=mars_map.yaml params_file:=nav2_params.yaml
 ```
 
 ## Terminal 4 - launch Rviz
@@ -38,7 +38,7 @@ ros2 launch nav2_bringup localization_launch.py use_sim_time:=True map:=mars_map
 Exec into the same space_nav2 container and launch Rviz2:
 
 ```
-docker exec -it -e DISPLAY=:0 osrf_space_nav2_demo bash
+docker exec -it -e DISPLAY osrf_space_nav2_demo bash
 source /opt/ros/humble/setup.bash
 source install/setup.bash
 ros2 launch nav2_bringup rviz_launch.py

--- a/navigation2/Dockerfile
+++ b/navigation2/Dockerfile
@@ -41,69 +41,36 @@ LABEL org.label-schema.vcs-ref=${VCS_REF}
 # Disable prompting during package installation
 ARG DEBIAN_FRONTEND=noninteractive
 
+SHELL ["/bin/bash", "-c"]
+
 # Define workspace locations
 ENV NAVIGATION2_WS=${HOME_DIR}/nav2_ws
-ENV NAV2_DEPS_WS=${HOME_DIR}/nav2_deps_ws
 
-# Get the Navigation2 source code
 RUN mkdir -p ${NAVIGATION2_WS}/src
-WORKDIR ${NAVIGATION2_WS}/src
-ARG NAV2_BRANCH=humble
-RUN sudo git clone --branch $NAV2_BRANCH https://github.com/ros-navigation/navigation2.git
 
-# Get keys for Nav2 dependencies
 WORKDIR ${NAVIGATION2_WS}/
-SHELL ["/bin/bash", "-c"]
-RUN source ${SPACEROS_DIR}/install/setup.bash && sudo apt update && rosdep keys --from-paths src --ignore-src --rosdistro humble -y > ${NAVIGATION2_WS}/nav2_dep_keys.txt
 
-# Get rosinstall_generator
-RUN sudo apt-get update -y && sudo apt-get install -y python3-rosinstall-generator
+COPY navigation2.repos .
+COPY excluded-pkgs.txt .
+RUN vcs import --shallow src < navigation2.repos
+COPY --chown=spaceros-user:spaceros-user src/ src
 
-# Clone Space ROS sources temporarily as input to rosinstall_generator
-RUN mkdir ${SPACEROS_DIR}/src \
-  && vcs import ${SPACEROS_DIR}/src < ${SPACEROS_DIR}/exact.repos
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \ 
+    source ${SPACEROS_DIR}/install/setup.bash && \
+    sudo apt update && \
+    rosdep install -i --from-path src --skip-keys $(cat excluded-pkgs.txt) -y
+RUN source ${SPACEROS_DIR}/install/setup.bash && \
+    colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON --no-warn-unused-cli
+RUN rm -rf src build log
 
-# Generate repos file for nav2 dependencies, exclude packages from Space ROS src
-RUN rosinstall_generator \
-  --rosdistro ${ROS_DISTRO} \
-  --deps \
-  --exclude-path ${SPACEROS_DIR}/src -- \
-  -- $(cat ${NAVIGATION2_WS}/nav2_dep_keys.txt) \
-  > ${NAVIGATION2_WS}/nav2_deps.repos
 
-# Remove unneeded src files now that repos are generated
-RUN rm -rf ${SPACEROS_DIR}/src
-
-# Get the repositories required by Nav2
-RUN mkdir -p ${NAV2_DEPS_WS}/src
-WORKDIR ${NAV2_DEPS_WS}
-RUN sudo vcs import src < ${NAVIGATION2_WS}/nav2_deps.repos
-
-# Update the ownership of the source files
-RUN sudo chown -R ${USERNAME}:${USERNAME} ${NAV2_DEPS_WS}
-
-# Install nav2_deps_ws dependencies
-SHELL ["/bin/bash", "-c"]
-RUN source ${SPACEROS_DIR}/install/setup.bash && sudo apt update && rosdep install --from-paths src --ignore-src --rosdistro humble -y \
-      --skip-keys "composition demo_nodes_py ikos lifecycle rmw_connextdds rmw_fastrtps_dynamic_cpp rmw_fastrtps_cpp \
-                   rosidl_typesupport_fastrtps_c rosidl_typesupport_fastrtps_cpp urdfdom_headers"
-
-# Build dependencies
-RUN source ${SPACEROS_DIR}/install/setup.bash && colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
-
-# Install remaining nav2 dependencies (not in rosdistro)
-WORKDIR ${NAVIGATION2_WS}
-SHELL ["/bin/bash", "-c"]
-RUN source ${NAV2_DEPS_WS}/install/setup.bash && sudo apt update && rosdep install --from-paths src --ignore-src --rosdistro humble -y \
-      --skip-keys "composition demo_nodes_py ikos lifecycle rmw_connextdds rmw_fastrtps_dynamic_cpp rmw_fastrtps_cpp \
-                   rosidl_typesupport_fastrtps_c rosidl_typesupport_fastrtps_cpp urdfdom_headers"
-
-# Build Navigation2
-SHELL ["/bin/bash", "-c"]
-RUN source ${NAV2_DEPS_WS}/install/setup.bash && colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
-
-# Install rviz2 to send goals to Nav2
-RUN sudo apt update && sudo apt install -y ros-humble-rviz2
+# Install rviz2 to send goals to Nav2. 
+# TODO(xfiderek): Remove rviz2 and humble-nav2 froms this image
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \  
+    sudo apt update && \
+    sudo apt install -y ros-humble-rviz2 ros-humble-nav2-bringup
 
 # Set up the entrypoint
 COPY ./entrypoint.sh /

--- a/navigation2/README.md
+++ b/navigation2/README.md
@@ -1,7 +1,9 @@
 # Navigation2 Docker Image
 
 The Navigation2 Docker image uses the Space ROS docker image (*osrf/space-ros:latest*) as its base image.
-The Navigation2 Dockerfile installs all of the prerequisite system dependencies to build Navigation2
+The Navigation2 Dockerfile installs all of the prerequisite system dependencies to build Navigation2.
+All the required nav2 packages are cloned and built from sources using the `navigation2.repos` file. The `nav2_rviz_plugins` and `nav2_bringup` packages together with their dependencies (Rviz, Gazebo, etc) are excluded to reduce package dependencies. The image also contains a custom `space_nav2_bringup` package that can be used as a starting point for creating mission-specific nav2 launch files.
+
 ## Building the Navigation2 Image
 
 To build the docker image, run:
@@ -33,8 +35,7 @@ The output will look something like this:
 ```
 REPOSITORY              TAG                        IMAGE ID       CREATED        SIZE
 osrf/space_nav2         latest                     6edb2edc9643   10 hours ago   15.5GB
-openrobotics/spaceros   latest                     629b13cf7b74   12 hours ago   7.8GB
-nvidia/cudagl           11.4.1-devel-ubuntu20.04   336416dfcbba   1 week ago     5.35GB
+osrf/space-ros           latest                     629b13cf7b74   12 hours ago   7.8GB
 ```
 
 The new image is named **osrf/space_nav2:latest**.
@@ -45,13 +46,34 @@ There is a run.sh script provided for convenience that will run the spaceros ima
 ./run.sh
 ```
 
-Upon startup, the container automatically runs the entrypoint.sh script, which sources the MoveIt2 and Space ROS environment files.
+Upon startup, the container automatically runs the entrypoint.sh script, which sources the Nav2 and Space ROS environment files.
 You'll now be running inside the container and should see a prompt similar to this:
 
 ```
-root@ip-your-ip-address:/home/spaceros-user/nav2_ws#
+spaceros-user@ip-your-ip-address:/home/spaceros-user/nav2_ws#
 ```
 
 ## Running Navigation2 Demo
 
-To run the latest demo, see the README in the nav2_demos folder
+To run the latest demo, see the README in the [nav2_demo](../nav2_demo/README.md) folder.
+
+## Updating navigation2 packages
+
+The `navigation2.repos` file available in this repository provides a list of repos that are required to build the nav2 stack. ROS packages already included in the SpaceROS base image are omited from this file.
+
+To update navigation2 packages used to build the space nav2 image, run the `docker_update_nav2_repos.sh` script:
+
+```
+./docker_update_nav2_repos.sh
+```
+
+This will update the `navigation2.repos` file with the newest versions of nav2 packages. The script resolves missing packages in base spaceros image and creates a list with their latest versions. The `navigation2.repos` file is then copied during build to the docker image with space nav2, and packages specified in the file are cloned and installed.
+
+By default, this update nav2 repositories using the latest released version of the Space ROS base image (typically `osrf/space-ros:latest`).
+If building locally, the underlying base image can be set in the through the environment with:
+
+```
+SPACE_ROS_IMAGE=osrf/space-ros:main ./docker_update_nav2_repos.sh
+```
+
+To generate a list of required packages for any other ROS workspace (e.g. your custom workspace built on top of SpaceROS that already has some nav2 dependencies installed), consider using the `update_nav2_repos.sh` as your starting point. You may also need to clone `generate-repos.sh` script from the main spaceros repository.

--- a/navigation2/docker_update_nav2_repos.sh
+++ b/navigation2/docker_update_nav2_repos.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+SPACE_ROS_IMAGE="${SPACE_ROS_IMAGE:-osrf/space-ros:latest}"
+
+docker run --rm \
+    -v ./:/home/spaceros-user/mount/ \
+    -w /home/spaceros-user/mount/ \
+    $SPACE_ROS_IMAGE \
+    bash -c './update_nav2_repos.sh'

--- a/navigation2/excluded-pkgs.txt
+++ b/navigation2/excluded-pkgs.txt
@@ -1,0 +1,1 @@
+nav2_rviz_plugins

--- a/navigation2/navigation2-pkgs.txt
+++ b/navigation2/navigation2-pkgs.txt
@@ -1,0 +1,1 @@
+navigation2

--- a/navigation2/navigation2.repos
+++ b/navigation2/navigation2.repos
@@ -1,70 +1,190 @@
 repositories:
-   BehaviorTree/BehaviorTree.CPP:
-     type: git
-     url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
-     version: v3.8
-   diagnostics:
-     type: git
-     url: https://github.com/ros/diagnostics.git
-     version: ros2
-   ignition/ignition_cmake2_vendor:
-     type: git
-     url: https://github.com/ignition-release/ignition_cmake2_vendor.git
-     version: rolling
-   ignition_math6_vendor:
-     type: git
-     url: https://github.com/ignition-release/ignition_math6_vendor.git
-     version: rolling
-   image_common:
-     type: git
-     url: https://github.com/ros-perception/image_common.git
-     version: rolling
-   interactive_markers:
-     type: git
-     url: https://github.com/ros-visualization/interactive_markers.git
-     version: ros2
-   laser_geometry:
-     type: git
-     url: https://github.com/ros-perception/laser_geometry.git
-     version: rolling
-   map_msgs:
-     type: git
-     url: https://github.com/ros-navigation/navigation_msgs.git
-     version: rolling
-   ompl/ompl:
-     type: git
-     url: https://github.com/ompl/ompl.git
-     version: main
-   ros/angles:
-     type: git
-     url: https://github.com/ros/angles.git
-     version: ros2
-   ros-perception/vision_opencv:
-     type: git
-     url: https://github.com/ros-perception/vision_opencv.git
-     version: humble
-   ros-simulation/gazebo_ros_pkgs:
-     type: git
-     url: https://github.com/ros-simulation/gazebo_ros_pkgs.git
-     version: ros2
-   ros/bond_core:
-     type: git
-     url: https://github.com/ros/bond_core.git
-     version: ros2
-   resource_retriever:
-     type: git
-     url: https://github.com/ros/resource_retriever.git
-     version: rolling
-   rviz:
-     type: git
-     url: https://github.com/ros2/rviz.git
-     version: ros2
-   slam_toolbox:
-     type: git
-     url: https://github.com/SteveMacenski/slam_toolbox.git
-     version: ros2
-   yaml_cpp_vendor:
-     type: git
-     url: https://github.com/ros2/yaml_cpp_vendor.git
-     version: humble
+  angles:
+    type: git
+    url: https://github.com/ros2-gbp/angles-release.git
+    version: release/humble/angles/1.15.0-1
+  behaviortree_cpp_v3:
+    type: git
+    url: https://github.com/BehaviorTree/behaviortree_cpp_v3-release.git
+    version: release/humble/behaviortree_cpp_v3/3.8.7-1
+  bond_core/bond:
+    type: git
+    url: https://github.com/ros2-gbp/bond_core-release.git
+    version: release/humble/bond/3.0.2-3
+  bond_core/bondcpp:
+    type: git
+    url: https://github.com/ros2-gbp/bond_core-release.git
+    version: release/humble/bondcpp/3.0.2-3
+  bond_core/smclib:
+    type: git
+    url: https://github.com/ros2-gbp/bond_core-release.git
+    version: release/humble/smclib/3.0.2-3
+  diagnostics/diagnostic_updater:
+    type: git
+    url: https://github.com/ros2-gbp/diagnostics-release.git
+    version: release/humble/diagnostic_updater/4.0.0-1
+  image_common/image_transport:
+    type: git
+    url: https://github.com/ros2-gbp/image_common-release.git
+    version: release/humble/image_transport/3.1.9-1
+  laser_geometry:
+    type: git
+    url: https://github.com/ros2-gbp/laser_geometry-release.git
+    version: release/humble/laser_geometry/2.4.0-2
+  map_msgs:
+    type: git
+    url: https://github.com/ros2-gbp/navigation_msgs-release.git
+    version: release/humble/map_msgs/2.1.0-3
+  navigation2/costmap_queue:
+    type: git
+    url: https://github.com/SteveMacenski/navigation2-release.git
+    version: release/humble/costmap_queue/1.1.16-1
+  navigation2/dwb_core:
+    type: git
+    url: https://github.com/SteveMacenski/navigation2-release.git
+    version: release/humble/dwb_core/1.1.16-1
+  navigation2/dwb_critics:
+    type: git
+    url: https://github.com/SteveMacenski/navigation2-release.git
+    version: release/humble/dwb_critics/1.1.16-1
+  navigation2/dwb_msgs:
+    type: git
+    url: https://github.com/SteveMacenski/navigation2-release.git
+    version: release/humble/dwb_msgs/1.1.16-1
+  navigation2/dwb_plugins:
+    type: git
+    url: https://github.com/SteveMacenski/navigation2-release.git
+    version: release/humble/dwb_plugins/1.1.16-1
+  navigation2/nav2_amcl:
+    type: git
+    url: https://github.com/SteveMacenski/navigation2-release.git
+    version: release/humble/nav2_amcl/1.1.16-1
+  navigation2/nav2_behavior_tree:
+    type: git
+    url: https://github.com/SteveMacenski/navigation2-release.git
+    version: release/humble/nav2_behavior_tree/1.1.16-1
+  navigation2/nav2_behaviors:
+    type: git
+    url: https://github.com/SteveMacenski/navigation2-release.git
+    version: release/humble/nav2_behaviors/1.1.16-1
+  navigation2/nav2_bt_navigator:
+    type: git
+    url: https://github.com/SteveMacenski/navigation2-release.git
+    version: release/humble/nav2_bt_navigator/1.1.16-1
+  navigation2/nav2_collision_monitor:
+    type: git
+    url: https://github.com/SteveMacenski/navigation2-release.git
+    version: release/humble/nav2_collision_monitor/1.1.16-1
+  navigation2/nav2_common:
+    type: git
+    url: https://github.com/SteveMacenski/navigation2-release.git
+    version: release/humble/nav2_common/1.1.16-1
+  navigation2/nav2_constrained_smoother:
+    type: git
+    url: https://github.com/SteveMacenski/navigation2-release.git
+    version: release/humble/nav2_constrained_smoother/1.1.16-1
+  navigation2/nav2_controller:
+    type: git
+    url: https://github.com/SteveMacenski/navigation2-release.git
+    version: release/humble/nav2_controller/1.1.16-1
+  navigation2/nav2_core:
+    type: git
+    url: https://github.com/SteveMacenski/navigation2-release.git
+    version: release/humble/nav2_core/1.1.16-1
+  navigation2/nav2_costmap_2d:
+    type: git
+    url: https://github.com/SteveMacenski/navigation2-release.git
+    version: release/humble/nav2_costmap_2d/1.1.16-1
+  navigation2/nav2_dwb_controller:
+    type: git
+    url: https://github.com/SteveMacenski/navigation2-release.git
+    version: release/humble/nav2_dwb_controller/1.1.16-1
+  navigation2/nav2_lifecycle_manager:
+    type: git
+    url: https://github.com/SteveMacenski/navigation2-release.git
+    version: release/humble/nav2_lifecycle_manager/1.1.16-1
+  navigation2/nav2_map_server:
+    type: git
+    url: https://github.com/SteveMacenski/navigation2-release.git
+    version: release/humble/nav2_map_server/1.1.16-1
+  navigation2/nav2_mppi_controller:
+    type: git
+    url: https://github.com/SteveMacenski/navigation2-release.git
+    version: release/humble/nav2_mppi_controller/1.1.16-1
+  navigation2/nav2_msgs:
+    type: git
+    url: https://github.com/SteveMacenski/navigation2-release.git
+    version: release/humble/nav2_msgs/1.1.16-1
+  navigation2/nav2_navfn_planner:
+    type: git
+    url: https://github.com/SteveMacenski/navigation2-release.git
+    version: release/humble/nav2_navfn_planner/1.1.16-1
+  navigation2/nav2_planner:
+    type: git
+    url: https://github.com/SteveMacenski/navigation2-release.git
+    version: release/humble/nav2_planner/1.1.16-1
+  navigation2/nav2_regulated_pure_pursuit_controller:
+    type: git
+    url: https://github.com/SteveMacenski/navigation2-release.git
+    version: release/humble/nav2_regulated_pure_pursuit_controller/1.1.16-1
+  navigation2/nav2_rotation_shim_controller:
+    type: git
+    url: https://github.com/SteveMacenski/navigation2-release.git
+    version: release/humble/nav2_rotation_shim_controller/1.1.16-1
+  navigation2/nav2_simple_commander:
+    type: git
+    url: https://github.com/SteveMacenski/navigation2-release.git
+    version: release/humble/nav2_simple_commander/1.1.16-1
+  navigation2/nav2_smac_planner:
+    type: git
+    url: https://github.com/SteveMacenski/navigation2-release.git
+    version: release/humble/nav2_smac_planner/1.1.16-1
+  navigation2/nav2_smoother:
+    type: git
+    url: https://github.com/SteveMacenski/navigation2-release.git
+    version: release/humble/nav2_smoother/1.1.16-1
+  navigation2/nav2_theta_star_planner:
+    type: git
+    url: https://github.com/SteveMacenski/navigation2-release.git
+    version: release/humble/nav2_theta_star_planner/1.1.16-1
+  navigation2/nav2_util:
+    type: git
+    url: https://github.com/SteveMacenski/navigation2-release.git
+    version: release/humble/nav2_util/1.1.16-1
+  navigation2/nav2_velocity_smoother:
+    type: git
+    url: https://github.com/SteveMacenski/navigation2-release.git
+    version: release/humble/nav2_velocity_smoother/1.1.16-1
+  navigation2/nav2_voxel_grid:
+    type: git
+    url: https://github.com/SteveMacenski/navigation2-release.git
+    version: release/humble/nav2_voxel_grid/1.1.16-1
+  navigation2/nav2_waypoint_follower:
+    type: git
+    url: https://github.com/SteveMacenski/navigation2-release.git
+    version: release/humble/nav2_waypoint_follower/1.1.16-1
+  navigation2/nav_2d_msgs:
+    type: git
+    url: https://github.com/SteveMacenski/navigation2-release.git
+    version: release/humble/nav_2d_msgs/1.1.16-1
+  navigation2/nav_2d_utils:
+    type: git
+    url: https://github.com/SteveMacenski/navigation2-release.git
+    version: release/humble/nav_2d_utils/1.1.16-1
+  navigation2/navigation2:
+    type: git
+    url: https://github.com/SteveMacenski/navigation2-release.git
+    version: release/humble/navigation2/1.1.16-1
+  ompl:
+    type: git
+    url: https://github.com/ros2-gbp/ompl-release.git
+    version: release/humble/ompl/1.6.0-1
+  vision_opencv/cv_bridge:
+    type: git
+    url: https://github.com/ros2-gbp/vision_opencv-release.git
+    version: release/humble/cv_bridge/3.2.1-1
+  yaml_cpp_vendor:
+    type: git
+    url: https://github.com/ros2-gbp/yaml_cpp_vendor-release.git
+    version: release/humble/yaml_cpp_vendor/8.0.2-1
 

--- a/navigation2/src/space_nav2_bringup/CMakeLists.txt
+++ b/navigation2/src/space_nav2_bringup/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.8)
+project(space_nav2_bringup)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+
+install(DIRECTORY launch DESTINATION share/${PROJECT_NAME}/)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  set(ament_cmake_copyright_FOUND TRUE)
+  set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/navigation2/src/space_nav2_bringup/launch/localization_launch.py
+++ b/navigation2/src/space_nav2_bringup/launch/localization_launch.py
@@ -1,0 +1,192 @@
+# Copyright (c) 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from ament_index_python.packages import get_package_share_directory
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, GroupAction, SetEnvironmentVariable
+from launch.conditions import IfCondition
+from launch.substitutions import LaunchConfiguration, PythonExpression
+from launch_ros.actions import LoadComposableNodes
+from launch_ros.actions import Node
+from launch_ros.descriptions import ComposableNode, ParameterFile
+from nav2_common.launch import RewrittenYaml
+
+
+def generate_launch_description():
+    # Get the launch directory
+    bringup_dir = get_package_share_directory('space_nav2_bringup')
+
+    namespace = LaunchConfiguration('namespace')
+    map_yaml_file = LaunchConfiguration('map')
+    use_sim_time = LaunchConfiguration('use_sim_time')
+    autostart = LaunchConfiguration('autostart')
+    params_file = LaunchConfiguration('params_file')
+    use_composition = LaunchConfiguration('use_composition')
+    container_name = LaunchConfiguration('container_name')
+    container_name_full = (namespace, '/', container_name)
+    use_respawn = LaunchConfiguration('use_respawn')
+    log_level = LaunchConfiguration('log_level')
+
+    lifecycle_nodes = ['map_server', 'amcl']
+
+    # Map fully qualified names to relative ones so the node's namespace can be prepended.
+    # In case of the transforms (tf), currently, there doesn't seem to be a better alternative
+    # https://github.com/ros/geometry2/issues/32
+    # https://github.com/ros/robot_state_publisher/pull/30
+    # TODO(orduno) Substitute with `PushNodeRemapping`
+    #              https://github.com/ros2/launch_ros/issues/56
+    remappings = [('/tf', 'tf'),
+                  ('/tf_static', 'tf_static')]
+
+    # Create our own temporary YAML files that include substitutions
+    param_substitutions = {
+        'use_sim_time': use_sim_time,
+        'yaml_filename': map_yaml_file}
+
+    configured_params = ParameterFile(
+        RewrittenYaml(
+            source_file=params_file,
+            root_key=namespace,
+            param_rewrites=param_substitutions,
+            convert_types=True),
+        allow_substs=True)
+
+    stdout_linebuf_envvar = SetEnvironmentVariable(
+        'RCUTILS_LOGGING_BUFFERED_STREAM', '1')
+
+    declare_namespace_cmd = DeclareLaunchArgument(
+        'namespace',
+        default_value='',
+        description='Top-level namespace')
+
+    declare_map_yaml_cmd = DeclareLaunchArgument(
+        'map',
+        description='Full path to map yaml file to load')
+
+    declare_use_sim_time_cmd = DeclareLaunchArgument(
+        'use_sim_time',
+        default_value='false',
+        description='Use simulation (Gazebo) clock if true')
+
+    declare_params_file_cmd = DeclareLaunchArgument(
+        'params_file',
+        default_value=os.path.join(bringup_dir, 'params', 'nav2_params.yaml'),
+        description='Full path to the ROS2 parameters file to use for all launched nodes')
+
+    declare_autostart_cmd = DeclareLaunchArgument(
+        'autostart', default_value='true',
+        description='Automatically startup the nav2 stack')
+
+    declare_use_composition_cmd = DeclareLaunchArgument(
+        'use_composition', default_value='False',
+        description='Use composed bringup if True')
+
+    declare_container_name_cmd = DeclareLaunchArgument(
+        'container_name', default_value='nav2_container',
+        description='the name of conatiner that nodes will load in if use composition')
+
+    declare_use_respawn_cmd = DeclareLaunchArgument(
+        'use_respawn', default_value='False',
+        description='Whether to respawn if a node crashes. Applied when composition is disabled.')
+
+    declare_log_level_cmd = DeclareLaunchArgument(
+        'log_level', default_value='info',
+        description='log level')
+
+    load_nodes = GroupAction(
+        condition=IfCondition(PythonExpression(['not ', use_composition])),
+        actions=[
+            Node(
+                package='nav2_map_server',
+                executable='map_server',
+                name='map_server',
+                output='screen',
+                respawn=use_respawn,
+                respawn_delay=2.0,
+                parameters=[configured_params],
+                arguments=['--ros-args', '--log-level', log_level],
+                remappings=remappings),
+            Node(
+                package='nav2_amcl',
+                executable='amcl',
+                name='amcl',
+                output='screen',
+                respawn=use_respawn,
+                respawn_delay=2.0,
+                parameters=[configured_params],
+                arguments=['--ros-args', '--log-level', log_level],
+                remappings=remappings),
+            Node(
+                package='nav2_lifecycle_manager',
+                executable='lifecycle_manager',
+                name='lifecycle_manager_localization',
+                output='screen',
+                arguments=['--ros-args', '--log-level', log_level],
+                parameters=[{'use_sim_time': use_sim_time},
+                            {'autostart': autostart},
+                            {'node_names': lifecycle_nodes}])
+        ]
+    )
+
+    load_composable_nodes = LoadComposableNodes(
+        condition=IfCondition(use_composition),
+        target_container=container_name_full,
+        composable_node_descriptions=[
+            ComposableNode(
+                package='nav2_map_server',
+                plugin='nav2_map_server::MapServer',
+                name='map_server',
+                parameters=[configured_params],
+                remappings=remappings),
+            ComposableNode(
+                package='nav2_amcl',
+                plugin='nav2_amcl::AmclNode',
+                name='amcl',
+                parameters=[configured_params],
+                remappings=remappings),
+            ComposableNode(
+                package='nav2_lifecycle_manager',
+                plugin='nav2_lifecycle_manager::LifecycleManager',
+                name='lifecycle_manager_localization',
+                parameters=[{'use_sim_time': use_sim_time,
+                             'autostart': autostart,
+                             'node_names': lifecycle_nodes}]),
+        ],
+    )
+
+    # Create the launch description and populate
+    ld = LaunchDescription()
+
+    # Set environment variables
+    ld.add_action(stdout_linebuf_envvar)
+
+    # Declare the launch options
+    ld.add_action(declare_namespace_cmd)
+    ld.add_action(declare_map_yaml_cmd)
+    ld.add_action(declare_use_sim_time_cmd)
+    ld.add_action(declare_params_file_cmd)
+    ld.add_action(declare_autostart_cmd)
+    ld.add_action(declare_use_composition_cmd)
+    ld.add_action(declare_container_name_cmd)
+    ld.add_action(declare_use_respawn_cmd)
+    ld.add_action(declare_log_level_cmd)
+
+    # Add the actions to launch all of the localiztion nodes
+    ld.add_action(load_nodes)
+    ld.add_action(load_composable_nodes)
+
+    return ld

--- a/navigation2/src/space_nav2_bringup/launch/navigation_launch.py
+++ b/navigation2/src/space_nav2_bringup/launch/navigation_launch.py
@@ -1,0 +1,272 @@
+# Copyright (c) 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from ament_index_python.packages import get_package_share_directory
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, GroupAction, SetEnvironmentVariable
+from launch.conditions import IfCondition
+from launch.substitutions import LaunchConfiguration, PythonExpression
+from launch_ros.actions import LoadComposableNodes
+from launch_ros.actions import Node
+from launch_ros.descriptions import ComposableNode, ParameterFile
+from nav2_common.launch import RewrittenYaml
+
+
+def generate_launch_description():
+    # Get the launch directory
+    bringup_dir = get_package_share_directory('space_nav2_bringup')
+
+    namespace = LaunchConfiguration('namespace')
+    use_sim_time = LaunchConfiguration('use_sim_time')
+    autostart = LaunchConfiguration('autostart')
+    params_file = LaunchConfiguration('params_file')
+    use_composition = LaunchConfiguration('use_composition')
+    container_name = LaunchConfiguration('container_name')
+    container_name_full = (namespace, '/', container_name)
+    use_respawn = LaunchConfiguration('use_respawn')
+    log_level = LaunchConfiguration('log_level')
+
+    lifecycle_nodes = ['controller_server',
+                       'smoother_server',
+                       'planner_server',
+                       'behavior_server',
+                       'bt_navigator',
+                       'waypoint_follower',
+                       'velocity_smoother']
+
+    # Map fully qualified names to relative ones so the node's namespace can be prepended.
+    # In case of the transforms (tf), currently, there doesn't seem to be a better alternative
+    # https://github.com/ros/geometry2/issues/32
+    # https://github.com/ros/robot_state_publisher/pull/30
+    # TODO(orduno) Substitute with `PushNodeRemapping`
+    #              https://github.com/ros2/launch_ros/issues/56
+    remappings = [('/tf', 'tf'),
+                  ('/tf_static', 'tf_static')]
+
+    # Create our own temporary YAML files that include substitutions
+    param_substitutions = {
+        'use_sim_time': use_sim_time,
+        'autostart': autostart}
+
+    configured_params = ParameterFile(
+        RewrittenYaml(
+            source_file=params_file,
+            root_key=namespace,
+            param_rewrites=param_substitutions,
+            convert_types=True),
+        allow_substs=True)
+
+    stdout_linebuf_envvar = SetEnvironmentVariable(
+        'RCUTILS_LOGGING_BUFFERED_STREAM', '1')
+
+    declare_namespace_cmd = DeclareLaunchArgument(
+        'namespace',
+        default_value='',
+        description='Top-level namespace')
+
+    declare_use_sim_time_cmd = DeclareLaunchArgument(
+        'use_sim_time',
+        default_value='false',
+        description='Use simulation (Gazebo) clock if true')
+
+    declare_params_file_cmd = DeclareLaunchArgument(
+        'params_file',
+        default_value=os.path.join(bringup_dir, 'params', 'nav2_params.yaml'),
+        description='Full path to the ROS2 parameters file to use for all launched nodes')
+
+    declare_autostart_cmd = DeclareLaunchArgument(
+        'autostart', default_value='true',
+        description='Automatically startup the nav2 stack')
+
+    declare_use_composition_cmd = DeclareLaunchArgument(
+        'use_composition', default_value='False',
+        description='Use composed bringup if True')
+
+    declare_container_name_cmd = DeclareLaunchArgument(
+        'container_name', default_value='nav2_container',
+        description='the name of conatiner that nodes will load in if use composition')
+
+    declare_use_respawn_cmd = DeclareLaunchArgument(
+        'use_respawn', default_value='False',
+        description='Whether to respawn if a node crashes. Applied when composition is disabled.')
+
+    declare_log_level_cmd = DeclareLaunchArgument(
+        'log_level', default_value='info',
+        description='log level')
+
+    load_nodes = GroupAction(
+        condition=IfCondition(PythonExpression(['not ', use_composition])),
+        actions=[
+            Node(
+                package='nav2_controller',
+                executable='controller_server',
+                output='screen',
+                respawn=use_respawn,
+                respawn_delay=2.0,
+                parameters=[configured_params],
+                arguments=['--ros-args', '--log-level', log_level],
+                remappings=remappings + [('cmd_vel', 'cmd_vel_nav')]),
+            Node(
+                package='nav2_smoother',
+                executable='smoother_server',
+                name='smoother_server',
+                output='screen',
+                respawn=use_respawn,
+                respawn_delay=2.0,
+                parameters=[configured_params],
+                arguments=['--ros-args', '--log-level', log_level],
+                remappings=remappings),
+            Node(
+                package='nav2_planner',
+                executable='planner_server',
+                name='planner_server',
+                output='screen',
+                respawn=use_respawn,
+                respawn_delay=2.0,
+                parameters=[configured_params],
+                arguments=['--ros-args', '--log-level', log_level],
+                remappings=remappings),
+            Node(
+                package='nav2_behaviors',
+                executable='behavior_server',
+                name='behavior_server',
+                output='screen',
+                respawn=use_respawn,
+                respawn_delay=2.0,
+                parameters=[configured_params],
+                arguments=['--ros-args', '--log-level', log_level],
+                remappings=remappings),
+            Node(
+                package='nav2_bt_navigator',
+                executable='bt_navigator',
+                name='bt_navigator',
+                output='screen',
+                respawn=use_respawn,
+                respawn_delay=2.0,
+                parameters=[configured_params],
+                arguments=['--ros-args', '--log-level', log_level],
+                remappings=remappings),
+            Node(
+                package='nav2_waypoint_follower',
+                executable='waypoint_follower',
+                name='waypoint_follower',
+                output='screen',
+                respawn=use_respawn,
+                respawn_delay=2.0,
+                parameters=[configured_params],
+                arguments=['--ros-args', '--log-level', log_level],
+                remappings=remappings),
+            Node(
+                package='nav2_velocity_smoother',
+                executable='velocity_smoother',
+                name='velocity_smoother',
+                output='screen',
+                respawn=use_respawn,
+                respawn_delay=2.0,
+                parameters=[configured_params],
+                arguments=['--ros-args', '--log-level', log_level],
+                remappings=remappings +
+                        [('cmd_vel', 'cmd_vel_nav'), ('cmd_vel_smoothed', 'cmd_vel')]),
+            Node(
+                package='nav2_lifecycle_manager',
+                executable='lifecycle_manager',
+                name='lifecycle_manager_navigation',
+                output='screen',
+                arguments=['--ros-args', '--log-level', log_level],
+                parameters=[{'use_sim_time': use_sim_time},
+                            {'autostart': autostart},
+                            {'node_names': lifecycle_nodes}]),
+        ]
+    )
+
+    load_composable_nodes = LoadComposableNodes(
+        condition=IfCondition(use_composition),
+        target_container=container_name_full,
+        composable_node_descriptions=[
+            ComposableNode(
+                package='nav2_controller',
+                plugin='nav2_controller::ControllerServer',
+                name='controller_server',
+                parameters=[configured_params],
+                remappings=remappings + [('cmd_vel', 'cmd_vel_nav')]),
+            ComposableNode(
+                package='nav2_smoother',
+                plugin='nav2_smoother::SmootherServer',
+                name='smoother_server',
+                parameters=[configured_params],
+                remappings=remappings),
+            ComposableNode(
+                package='nav2_planner',
+                plugin='nav2_planner::PlannerServer',
+                name='planner_server',
+                parameters=[configured_params],
+                remappings=remappings),
+            ComposableNode(
+                package='nav2_behaviors',
+                plugin='behavior_server::BehaviorServer',
+                name='behavior_server',
+                parameters=[configured_params],
+                remappings=remappings),
+            ComposableNode(
+                package='nav2_bt_navigator',
+                plugin='nav2_bt_navigator::BtNavigator',
+                name='bt_navigator',
+                parameters=[configured_params],
+                remappings=remappings),
+            ComposableNode(
+                package='nav2_waypoint_follower',
+                plugin='nav2_waypoint_follower::WaypointFollower',
+                name='waypoint_follower',
+                parameters=[configured_params],
+                remappings=remappings),
+            ComposableNode(
+                package='nav2_velocity_smoother',
+                plugin='nav2_velocity_smoother::VelocitySmoother',
+                name='velocity_smoother',
+                parameters=[configured_params],
+                remappings=remappings +
+                           [('cmd_vel', 'cmd_vel_nav'), ('cmd_vel_smoothed', 'cmd_vel')]),
+            ComposableNode(
+                package='nav2_lifecycle_manager',
+                plugin='nav2_lifecycle_manager::LifecycleManager',
+                name='lifecycle_manager_navigation',
+                parameters=[{'use_sim_time': use_sim_time,
+                             'autostart': autostart,
+                             'node_names': lifecycle_nodes}]),
+        ],
+    )
+
+    # Create the launch description and populate
+    ld = LaunchDescription()
+
+    # Set environment variables
+    ld.add_action(stdout_linebuf_envvar)
+
+    # Declare the launch options
+    ld.add_action(declare_namespace_cmd)
+    ld.add_action(declare_use_sim_time_cmd)
+    ld.add_action(declare_params_file_cmd)
+    ld.add_action(declare_autostart_cmd)
+    ld.add_action(declare_use_composition_cmd)
+    ld.add_action(declare_container_name_cmd)
+    ld.add_action(declare_use_respawn_cmd)
+    ld.add_action(declare_log_level_cmd)
+    # Add the actions to launch all of the navigation nodes
+    ld.add_action(load_nodes)
+    ld.add_action(load_composable_nodes)
+
+    return ld

--- a/navigation2/src/space_nav2_bringup/package.xml
+++ b/navigation2/src/space_nav2_bringup/package.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>space_nav2_bringup</name>
+  <version>0.0.1</version>
+  <description>Example bringup scripts for Navigation2 package running in SpaceROS</description>
+  <maintainer email="fiderekblazej@gmail.com">Blazej Fiderek (xfiderek)</maintainer>
+  <maintainer email="hansenmattk@gmail.com">Matt Hansen (mkhansenbot)</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <exec_depend>nav2_common</exec_depend>
+  <exec_depend>navigation2</exec_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/navigation2/update_nav2_repos.sh
+++ b/navigation2/update_nav2_repos.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+source $SPACEROS_DIR/install/setup.bash
+SCRIPT_PATH="$SPACEROS_DIR/scripts"
+bash $SCRIPT_PATH/generate-repos.sh \
+    --rosdistro $ROS_DISTRO \
+    --packages navigation2-pkgs.txt \
+    --excluded-packages excluded-pkgs.txt \
+    --outfile navigation2.repos \
+    --upstream false # this allows us to select specific sub-packages from a single repo


### PR DESCRIPTION
This PR addresses: https://github.com/space-ros/docker/issues/142

This PR introduces the following changes
- Pin version of navigation2.repos to ensure reproducible builds
- Create update script according to diagram from here: https://github.com/space-ros/space-ros/discussions/166#discussioncomment-9894710. The script is called `docker_update_nav2_repos.sh`
- Simplify dockerfile
- Add `space_nav2_bringup` package allowing to launch nav2 stack (we had to get rid of nav2_bringup due to heavy dependencies such as rviz)
- Update nav2_demo accordingly -> update readme


Out of scope (will be fixed as part of different issues):
- Simplifying space_robots demo (e.g. excluding gazebo from space robots img)
- Optimizing image size of nav2 image -> will be addressed separately
- Move the docker image to stacks repo -> will be addressed separately
- Remove rviz2 from the image
