### PR TITLE
Update GH Organizations for MoveIt and Nav2 Repos

### DIFF
--- a/moveit2/Dockerfile
+++ b/moveit2/Dockerfile
@@ -91,9 +91,9 @@ RUN python3 -m pip install -U \
 
 # Get the MoveIt2 source code
 WORKDIR ${HOME_DIR}
-RUN sudo git clone https://github.com/ros-planning/moveit2.git -b ${ROSDISTRO} moveit2/src
+RUN sudo git clone https://github.com/moveit/moveit2.git -b ${ROSDISTRO} moveit2/src
 RUN cd ${MOVEIT2_DIR}/src \
-  && sudo git clone https://github.com/ros-planning/moveit2_tutorials.git -b ${ROSDISTRO}
+  && sudo git clone https://github.com/moveit/moveit2_tutorials.git -b ${ROSDISTRO}
 
 # Update the ownership of the source files (had to use sudo above to work around
 # a possible inherited 'insteadof' from the host that forces use of ssh

--- a/moveit2/moveit2_tutorials.repos
+++ b/moveit2/moveit2_tutorials.repos
@@ -1,11 +1,11 @@
 repositories:
   moveit_task_constructor:
     type: git
-    url: https://github.com/ros-planning/moveit_task_constructor.git
+    url: https://github.com/moveit/moveit_task_constructor.git
     version: humble
   moveit_visual_tools:
     type: git
-    url: https://github.com/ros-planning/moveit_visual_tools
+    url: https://github.com/moveit/moveit_visual_tools
     version: ros2
   rosparam_shortcuts:
     type: git

--- a/navigation2/Dockerfile
+++ b/navigation2/Dockerfile
@@ -46,7 +46,7 @@ ENV NAV2_DEPS_WS=${HOME_DIR}/nav2_deps_ws
 RUN mkdir -p ${NAVIGATION2_WS}/src
 WORKDIR ${NAVIGATION2_WS}/src
 ARG NAV2_BRANCH=humble
-RUN sudo git clone --branch $NAV2_BRANCH https://github.com/ros-planning/navigation2.git
+RUN sudo git clone --branch $NAV2_BRANCH https://github.com/ros-navigation/navigation2.git
 
 # Get keys for Nav2 dependencies
 WORKDIR ${NAVIGATION2_WS}/

--- a/navigation2/navigation2.repos
+++ b/navigation2/navigation2.repos
@@ -29,7 +29,7 @@ repositories:
      version: rolling
    map_msgs:
      type: git
-     url: https://github.com/ros-planning/navigation_msgs.git
+     url: https://github.com/ros-navigation/navigation_msgs.git
      version: rolling
    ompl/ompl:
      type: git

--- a/space_robots/demo_manual_pkgs.repos
+++ b/space_robots/demo_manual_pkgs.repos
@@ -29,7 +29,7 @@ repositories:
     version: main
   ros-humble-warehouse-ros-mongo:
     type: git
-    url: https://github.com/ros-planning/warehouse_ros_mongo.git
+    url: https://github.com/moveit/warehouse_ros_mongo.git
     version: ros2
   vision_msgs:
     type: git


### PR DESCRIPTION
Resolves https://github.com/space-ros/docker/issues/163.

Should be purely cosmetic changes to match the updated organizations post migration.