### PR TITLE
Fix renode rcc build failure (close #170)

### DIFF
--- a/renode_rcc/Dockerfile
+++ b/renode_rcc/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 WORKDIR /root
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 # Using Docker BuildKit cache mounts for /var/cache/apt and /var/lib/apt ensures that
 # the cache won't make it into the built image but will be maintained between steps.
@@ -36,9 +36,9 @@ WORKDIR /root/renode-rtems-leon3
 RUN ./build-rtems.sh
 RUN ./build-prom.sh
 RUN mv rcc-1.3.0-gcc/ /opt/renode/
-RUN mv grlib-gpl-2021.2-b4267 /opt/renode/
+RUN mv grlib-gpl-2024.1-b4291 /opt/renode/
 
-ENV PATH $PATH:/opt/renode/rcc-1.3.0-gcc/bin
+ENV PATH=$PATH:/opt/renode/rcc-1.3.0-gcc/bin
 
 WORKDIR /root
 COPY config .config/renode/


### PR DESCRIPTION
The [upstream repository](https://github.com/antmicro/renode-rtems-leon3) used by this Dockerfile updated their internal dependencies (https://github.com/antmicro/renode-rtems-leon3/commit/4e962e4783cb29c38ccdf8a11e879788f10c09a1) which are referenced by version number here: https://github.com/space-ros/docker/blob/ad020b80406974bb494f04a6a3f8216273a5489e/renode_rcc/Dockerfile#L39

I considered pinning the upstream version given the magic-numbers at play, but because git doesn't support cloning by commit hash, (and the upstream works without branches, tags, or releases), I opted to just fix the bug at hand and leave detection of future issues to the already open https://github.com/space-ros/docker/issues/69