### PR TITLE
NASA Challenge_[@elementrobotics]_[LunarSim] (closes space-ros/demos#50)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@
 __pycache__/
 *.py[cod]
 *$py.class
+
+*/space-ros-demos-er/

--- a/.gitignore
+++ b/.gitignore
@@ -35,5 +35,3 @@
 __pycache__/
 *.py[cod]
 *$py.class
-
-*/space-ros-demos-er/

--- a/lunar_sim/Dockerfile
+++ b/lunar_sim/Dockerfile
@@ -42,6 +42,7 @@ RUN mkdir ${SPACEROS_DIR}/src \
 # Define a few key variables
 ENV DEMO_DIR=${HOME_DIR}/demos_ws
 ENV GZ_VERSION garden
+ENV GZ_PARTITION spaceros
 
 # Disable prompting during package installation
 ARG DEBIAN_FRONTEND=noninteractive

--- a/lunar_sim/Dockerfile
+++ b/lunar_sim/Dockerfile
@@ -41,8 +41,8 @@ RUN mkdir ${SPACEROS_DIR}/src \
 
 # Define a few key variables
 ENV DEMO_DIR=${HOME_DIR}/demos_ws
-ENV GZ_VERSION garden
-ENV GZ_PARTITION spaceros
+ENV GZ_VERSION=garden
+ENV GZ_PARTITION=spaceros
 
 # Disable prompting during package installation
 ARG DEBIAN_FRONTEND=noninteractive
@@ -75,6 +75,10 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   python3-setuptools \
   python3-vcstool \
   wget
+
+RUN sudo add-apt-repository ppa:kisak/kisak-mesa
+
+RUN sudo apt install xterm -y
 
 # Get rosinstall_generator
 # Using Docker BuildKit cache mounts for /var/cache/apt and /var/lib/apt ensures that

--- a/lunar_sim/Dockerfile
+++ b/lunar_sim/Dockerfile
@@ -143,9 +143,6 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 && /bin/bash -c 'source "${SPACEROS_DIR}/install/setup.bash"' \
 && rosdep install --from-paths src --ignore-src -r -y --rosdistro ${ROSDISTRO}
 
-# Copy the demo source code
-COPY --chown=${USERNAME}:${USERNAME} space-ros-demos-er src/
-
 # Build the demo
 RUN /bin/bash -c 'source ${SPACEROS_DIR}/install/setup.bash \
   && colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release --packages-skip canadarm canadarm_moveit_config mars_rover space_ros_memory_allocation_demo'

--- a/lunar_sim/Dockerfile
+++ b/lunar_sim/Dockerfile
@@ -1,0 +1,157 @@
+# Copyright 2021 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# A Docker configuration script to build the Space ROS image.
+#
+# The script provides the following build arguments:
+#
+#   VCS_REF     - The git revision of the Space ROS source code (no default value).
+#   VERSION     - The version of Space ROS (default: "preview")
+
+FROM osrf/space-ros:latest
+
+# Define arguments used in the metadata definition
+ARG VCS_REF
+ARG VERSION="preview"
+
+# Specify the docker image metadata
+LABEL org.label-schema.schema-version="1.0"
+LABEL org.label-schema.name="Lunar Sim"
+LABEL org.label-schema.description="Lunar sim demo on the Space ROS platform"
+LABEL org.label-schema.vendor="Open Robotics"
+LABEL org.label-schema.version=${VERSION}
+LABEL org.label-schema.url="https://github.com/space-ros"
+LABEL org.label-schema.vcs-url="https://github.com/space-ros/docker"
+LABEL org.label-schema.vcs-ref=${VCS_REF}
+
+# Clone all space-ros sources
+RUN mkdir ${SPACEROS_DIR}/src \
+  && vcs import ${SPACEROS_DIR}/src < ${SPACEROS_DIR}/exact.repos
+
+# Define a few key variables
+ENV DEMO_DIR=${HOME_DIR}/demos_ws
+ENV GZ_VERSION garden
+
+# Disable prompting during package installation
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Make sure the latest versions of packages are installed
+# Using Docker BuildKit cache mounts for /var/cache/apt and /var/lib/apt ensures that
+# the cache won't make it into the built image but will be maintained between steps.
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  --mount=type=cache,target=/var/lib/apt,sharing=locked \
+  sudo apt-get update
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  --mount=type=cache,target=/var/lib/apt,sharing=locked \
+  sudo apt-get dist-upgrade -y
+RUN rosdep update
+
+# Install the various build and test tools
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  --mount=type=cache,target=/var/lib/apt,sharing=locked \
+  sudo apt install -y \
+  build-essential \
+  clang-format \
+  cmake \
+  git \
+  libbullet-dev \
+  python3-colcon-common-extensions \
+  python3-flake8 \
+  python3-pip \
+  python3-pytest-cov \
+  python3-rosdep \
+  python3-setuptools \
+  python3-vcstool \
+  wget
+
+# Get rosinstall_generator
+# Using Docker BuildKit cache mounts for /var/cache/apt and /var/lib/apt ensures that
+# the cache won't make it into the built image but will be maintained between steps.
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  --mount=type=cache,target=/var/lib/apt,sharing=locked \
+  sudo apt-get update -y && sudo apt-get install -y python3-rosinstall-generator
+
+# Install Gazebo Garder
+# Using Docker BuildKit cache mounts for /var/cache/apt and /var/lib/apt ensures that
+# the cache won't make it into the built image but will be maintained between steps.
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  --mount=type=cache,target=/var/lib/apt,sharing=locked \
+  sudo wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg \
+  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null \
+  && sudo apt-get update -y && sudo apt-get install -y gz-garden
+
+# Generate repos file for demo dependencies, excluding packages from Space ROS core.
+COPY --chown=${USERNAME}:${USERNAME} demo-pkgs.txt /tmp/
+COPY --chown=${USERNAME}:${USERNAME} excluded-pkgs.txt /tmp/
+RUN rosinstall_generator \
+  --rosdistro ${ROSDISTRO} \
+  --deps \
+  --exclude-path ${SPACEROS_DIR}/src \
+  --exclude $(cat /tmp/excluded-pkgs.txt) -- \
+  -- $(cat /tmp/demo-pkgs.txt) \
+  > /tmp/demo_generated_pkgs.repos
+
+ 
+RUN mkdir -p ${DEMO_DIR}/src
+WORKDIR ${DEMO_DIR}
+RUN vcs import src < /tmp/demo_generated_pkgs.repos
+
+# Install system dependencies
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  --mount=type=cache,target=/var/lib/apt,sharing=locked \
+  /bin/bash -c 'source ${SPACEROS_DIR}/install/setup.bash' \
+  && rosdep install --from-paths ../spaceros/src src --ignore-src --rosdistro ${ROSDISTRO} -r -y --skip-keys "console_bridge generate_parameter_library fastcdr fastrtps rti-connext-dds-5.3.1 urdfdom_headers rmw_connextdds ros_testing rmw_connextdds rmw_fastrtps_cpp rmw_fastrtps_dynamic_cpp composition demo_nodes_py lifecycle rosidl_typesupport_fastrtps_cpp rosidl_typesupport_fastrtps_c ikos diagnostic_aggregator diagnostic_updater joy qt_gui rqt_gui rqt_gui_py"
+
+
+# # Install libmongoc for development
+# RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+#   --mount=type=cache,target=/var/lib/apt,sharing=locked \
+#   sudo apt-get install libmongoc-dev -y
+
+# # Compile mongo cxx driver https://mongocxx.org/mongocxx-v3/installation/linux/
+# RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+#   --mount=type=cache,target=/var/lib/apt,sharing=locked \
+#   sudo apt-get install libssl-dev build-essential devscripts debian-keyring fakeroot debhelper cmake libboost-dev libsasl2-dev libicu-dev libzstd-dev doxygen -y
+# RUN wget https://github.com/mongodb/mongo-cxx-driver/releases/download/r3.6.7/mongo-cxx-driver-r3.6.7.tar.gz
+# RUN tar -xzf mongo-cxx-driver-r3.6.7.tar.gz
+# RUN cd mongo-cxx-driver-r3.6.7/build && cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local && sudo cmake --build . --target EP_mnmlstc_core && cmake --build . && sudo cmake --build . --target install
+
+# Get the source for the dependencies
+# RUN vcs import src < /tmp/demo_generated_pkgs.repos
+COPY --chown=${USERNAME}:${USERNAME} demo_manual_pkgs.repos /tmp/
+RUN vcs import src < /tmp/demo_manual_pkgs.repos && /bin/bash -c 'source "${SPACEROS_DIR}/install/setup.bash"' 
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  --mount=type=cache,target=/var/lib/apt,sharing=locked \
+  sudo apt-get update -y \
+&& /bin/bash -c 'source "${SPACEROS_DIR}/install/setup.bash"' \
+&& rosdep install --from-paths src --ignore-src -r -y --rosdistro ${ROSDISTRO}
+
+# Copy the demo source code
+COPY --chown=${USERNAME}:${USERNAME} space-ros-demos-er src/
+
+# Build the demo
+RUN /bin/bash -c 'source ${SPACEROS_DIR}/install/setup.bash \
+  && colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release --packages-skip canadarm canadarm_moveit_config mars_rover space_ros_memory_allocation_demo'
+
+# Create the render group if it doesn't exist
+RUN sudo groupadd -f render
+
+# Add the user to the render group so that the user can access /dev/dri/renderD128
+RUN sudo usermod -aG render $USERNAME
+
+# Setup the entrypoint
+COPY ./entrypoint.sh /
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["bash"]

--- a/lunar_sim/README.md
+++ b/lunar_sim/README.md
@@ -1,1 +1,63 @@
 # Space ROS Lunar Sim Demo Docker Image
+
+The Space ROS Lunar Sim Demo docker image uses the spaceros docker image (*osrf/space-ros:latest*) as its base image.
+The Dockerfile installs all of the prerequisite system dependencies along with the demo source code, then builds the Space ROS Lunar Sim Demo.
+
+This demo includes a Gazebo simulation of the lunar environment (specfically around the Shackleton crater near the south pole). It uses
+Digital Elevation Models (DEMs) from the Lunar Orbiter Laser Altimeter (LOLA) to accurately simulate the lunar surface in a specific region. It also contains a dynamic model of the Sun that moves according to Ephemeris data.  
+
+## Building the Demo Docker
+
+The demo image builds on top of the `spaceros` image.
+To build the docker image, first ensure the `spaceros` base image is available either by [building it locally](https://github.com/space-ros/space-ros) or pulling it.
+
+Then build `lunar_sim` demo images:
+
+```bash
+cd ../lunar_sim
+./build.sh
+```
+
+## Running the Demo Docker
+
+run the following to allow GUI passthrough:
+```bash
+xhost +local:docker
+```
+
+Then run:
+```bash
+./run.sh
+```
+
+Depending on the host computer, you might need to remove the ```--gpus all``` flag in ```run.sh```, which uses your GPUs.
+
+## Running the Demos
+
+### Curiosity Mars rover demo
+Launch the demo:
+```bash
+source install/setup.bash
+ros2 launch lunarsim_gz_bringup lunarsim_world.launch.py
+```
+
+### Perform Tasks
+
+#### Setup
+
+Open a new terminal and attach to the currently running container:
+
+```bash
+docker exec -it <container-name> bash
+```
+
+Make sure packages are sourced:
+
+```bash
+source ~/spaceros/install/setup.bash
+```
+
+```bash
+source ~/demos_ws/install/setup.bash
+```
+

--- a/lunar_sim/README.md
+++ b/lunar_sim/README.md
@@ -1,0 +1,1 @@
+# Space ROS Lunar Sim Demo Docker Image

--- a/lunar_sim/README.md
+++ b/lunar_sim/README.md
@@ -26,6 +26,7 @@ xhost +local:docker
 ```
 
 Then run:
+
 ```bash
 ./run.sh
 ```
@@ -35,29 +36,12 @@ Depending on the host computer, you might need to remove the ```--gpus all``` fl
 ## Running the Demos
 
 ### Curiosity Mars rover demo
+
 Launch the demo:
+
 ```bash
 source install/setup.bash
 ros2 launch lunarsim_gz_bringup lunarsim_world.launch.py
 ```
 
-### Perform Tasks
-
-#### Setup
-
-Open a new terminal and attach to the currently running container:
-
-```bash
-docker exec -it <container-name> bash
-```
-
-Make sure packages are sourced:
-
-```bash
-source ~/spaceros/install/setup.bash
-```
-
-```bash
-source ~/demos_ws/install/setup.bash
-```
-
+This will launch the gazebo lunar world, spawn the rover and start teleop. This will be a new terminal window which enables you to control the rover as per the instructions in the terminal window.

--- a/lunar_sim/build.sh
+++ b/lunar_sim/build.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+ORG=openrobotics
+IMAGE=space_robots_lunarsim_demo
+TAG=latest
+
+VCS_REF=""
+VERSION=preview
+
+# Exit script with failure if build fails
+set -eo pipefail
+
+echo ""
+echo "##### Building Space ROS Demo Docker Image #####"
+echo ""
+
+docker build -t $ORG/$IMAGE:$TAG \
+    --build-arg VCS_REF="$VCS_REF" \
+    --build-arg VERSION="$VERSION" .
+
+echo ""
+echo "##### Done! #####"
+

--- a/lunar_sim/demo-pkgs.txt
+++ b/lunar_sim/demo-pkgs.txt
@@ -1,4 +1,4 @@
 leo_gz_plugins
-leo_description
 rviz2
 xacro
+teleop_twist_keyboard

--- a/lunar_sim/demo-pkgs.txt
+++ b/lunar_sim/demo-pkgs.txt
@@ -1,0 +1,4 @@
+leo_gz_plugins
+leo_description
+rviz2
+xacro

--- a/lunar_sim/demo_manual_pkgs.repos
+++ b/lunar_sim/demo_manual_pkgs.repos
@@ -1,0 +1,18 @@
+repositories:
+  actuator_msgs:
+    type: git
+    url: https://github.com/rudislabs/actuator_msgs.git
+    version: main
+  ros_gz:
+    type: git
+    url: https://github.com/gazebosim/ros_gz.git
+    version: humble
+  vision_msgs:
+    type: git
+    url: https://github.com/ros-perception/vision_msgs.git
+    version: ros2
+  gps_msgs:
+    type: git
+    url: https://github.com/swri-robotics/gps_umd.git
+    path: gps_msgs
+    version: 113782d

--- a/lunar_sim/demo_manual_pkgs.repos
+++ b/lunar_sim/demo_manual_pkgs.repos
@@ -1,4 +1,8 @@
 repositories:
+  demos:
+    type: git
+    url: https://github.com/element-robotics/demos.git
+    version: feature/lunarsim
   actuator_msgs:
     type: git
     url: https://github.com/rudislabs/actuator_msgs.git

--- a/lunar_sim/demo_manual_pkgs.repos
+++ b/lunar_sim/demo_manual_pkgs.repos
@@ -16,3 +16,8 @@ repositories:
     url: https://github.com/swri-robotics/gps_umd.git
     path: gps_msgs
     version: 113782d
+
+  leo_common-ros2:
+    type: git
+    url: https://github.com/LeoRover/leo_common-ros2.git
+    version: humble

--- a/lunar_sim/entrypoint.sh
+++ b/lunar_sim/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+# Setup the Demo environment
+source "${DEMO_DIR}/install/setup.bash"
+exec "$@"

--- a/lunar_sim/excluded-pkgs.txt
+++ b/lunar_sim/excluded-pkgs.txt
@@ -1,0 +1,10 @@
+fastrtps
+fastcdr
+generate_parameter_library
+rmw_fastrtps_cpp
+rmw_fastrtps_dynamic_cpp
+rmw_fastrtps_shared_cpp
+rmw_connextdds
+rosidl_typesupport_fastrtps_c
+rosidl_typesupport_fastrtps_cpp
+fastrtps_cmake_module

--- a/lunar_sim/run.sh
+++ b/lunar_sim/run.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# Runs a docker container with the image created by build.bash
+# Requires:
+#   docker
+#   an X server
+
+IMG_NAME=openrobotics/space_robots_lunarsim_demo
+
+# Replace `/` with `_` to comply with docker container naming
+# And append `_runtime`
+CONTAINER_NAME="$(tr '/' '_' <<< "$IMG_NAME")"
+
+# Start the container
+docker run --rm -it --name $CONTAINER_NAME  --network host \
+    -e DISPLAY -e TERM   -e QT_X11_NO_MITSHM=1 $IMG_NAME


### PR DESCRIPTION
Depends on space-ros/demos#51

This PR adds in a dockerfile to build an image that runs the Lunar Sim demo as well as instructions on how to build and run it. The docker image is built on top of the spaceros base image, but installs and sets Gazebo Garden as the default Gazebo version due to improved heightmap capabilities compared to Fortress.

> [!NOTE]
> The demos repo in the lunar_sim/demo_manual_pkgs.repos file currently points to the fork with the LunarSim demo to enable testing of the demo, this needs to be changed back to the space-ros/demos repo once space-ros/demos#51 has been merged before merging this in.
