### PR TITLE
Fix remaining issues in applications and demos from the updated spaceros base image

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -20,6 +20,12 @@ jobs:
           # free up a lot of stuff from /usr/local
           sudo rm -rf /usr/local
           df -h
+      - name: Login to ghcr
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Checkout
         uses: actions/checkout@v2
       - name: Set up buildx
@@ -33,6 +39,8 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           no-cache: false
+          build-args: |
+            SPACE_ROS_IMAGE=ghcr.io/space-ros/space-ros:main
           outputs: type=docker,dest=/tmp/moveit2.tar
       - name: Build space robots demo image
         run: |

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -40,7 +40,7 @@ jobs:
           cache-to: type=gha,mode=max
           no-cache: false
           build-args: |
-            SPACE_ROS_IMAGE=ghcr.io/space-ros/space-ros:main
+            SPACE_ROS_IMAGE=osrf/space-ros:main
           outputs: type=docker,dest=/tmp/moveit2.tar
       - name: Build space robots demo image
         run: |
@@ -63,3 +63,5 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           no-cache: false
+          build-args: |
+            SPACE_ROS_IMAGE=osrf/space-ros:main

--- a/moveit2/Dockerfile
+++ b/moveit2/Dockerfile
@@ -91,9 +91,9 @@ RUN python3 -m pip install -U \
 
 # Get the MoveIt2 source code
 WORKDIR ${HOME_DIR}
-RUN sudo git clone https://github.com/moveit/moveit2.git -b ${ROSDISTRO} moveit2/src
+RUN sudo git clone https://github.com/ros-planning/moveit2.git -b ${ROS_DISTRO} moveit2/src
 RUN cd ${MOVEIT2_DIR}/src \
-  && sudo git clone https://github.com/moveit/moveit2_tutorials.git -b ${ROSDISTRO}
+  && sudo git clone https://github.com/ros-planning/moveit2_tutorials.git -b ${ROS_DISTRO}
 
 # Update the ownership of the source files (had to use sudo above to work around
 # a possible inherited 'insteadof' from the host that forces use of ssh
@@ -108,7 +108,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 COPY --chown=${USERNAME}:${USERNAME} moveit2-pkgs.txt /tmp/
 COPY --chown=${USERNAME}:${USERNAME} excluded-pkgs.txt /tmp/
 RUN rosinstall_generator \
-  --rosdistro ${ROSDISTRO} \
+  --rosdistro ${ROS_DISTRO} \
   --deps \
   --exclude-path ${SPACEROS_DIR}/src \
   --exclude $(cat /tmp/excluded-pkgs.txt) -- \
@@ -129,7 +129,7 @@ RUN sudo chown -R ${USERNAME}:${USERNAME} ${MOVEIT2_DIR}
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   --mount=type=cache,target=/var/lib/apt,sharing=locked \
   /bin/bash -c 'source ${SPACEROS_DIR}/install/setup.bash' \
- && rosdep install --from-paths ../spaceros/src src --ignore-src --rosdistro ${ROSDISTRO} -r -y --skip-keys "console_bridge generate_parameter_library fastcdr fastrtps rti-connext-dds-5.3.1 urdfdom_headers rmw_connextdds ros_testing rmw_connextdds rmw_fastrtps_cpp rmw_fastrtps_dynamic_cpp composition demo_nodes_py lifecycle rosidl_typesupport_fastrtps_cpp rosidl_typesupport_fastrtps_c ikos diagnostic_aggregator diagnostic_updater joy qt_gui rqt_gui rqt_gui_py"
+ && rosdep install --from-paths ../spaceros/src src --ignore-src --rosdistro ${ROS_DISTRO} -r -y --skip-keys "console_bridge generate_parameter_library fastcdr fastrtps rti-connext-dds-5.3.1 urdfdom_headers rmw_connextdds ros_testing rmw_connextdds rmw_fastrtps_cpp rmw_fastrtps_dynamic_cpp composition demo_nodes_py lifecycle rosidl_typesupport_fastrtps_cpp rosidl_typesupport_fastrtps_c ikos diagnostic_aggregator diagnostic_updater joy qt_gui rqt_gui rqt_gui_py"
 
 # Apply a patch to octomap_msgs to work around a build issue
 COPY --chown=${USERNAME}:${USERNAME} octomap_fix.diff ./src/octomap_msgs

--- a/moveit2/Dockerfile
+++ b/moveit2/Dockerfile
@@ -16,10 +16,13 @@
 #
 # The script provides the following build arguments:
 #
-#   VCS_REF     - The git revision of the Space ROS source code (no default value).
-#   VERSION     - The version of Space ROS (default: "preview")
+#   VCS_REF         - The git revision of the Space ROS source code (no default value).
+#   VERSION         - The version of Space ROS (default: "preview")
+#   SPACE_ROS_IMAGE - The base Space ROS image to build on
 
-FROM osrf/space-ros:latest
+ARG SPACE_ROS_IMAGE=osrf/space-ros:latest
+
+FROM ${SPACE_ROS_IMAGE}
 
 # Define arguments used in the metadata definition
 ARG VCS_REF

--- a/moveit2/Dockerfile
+++ b/moveit2/Dockerfile
@@ -129,7 +129,7 @@ RUN sudo chown -R ${USERNAME}:${USERNAME} ${MOVEIT2_DIR}
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   --mount=type=cache,target=/var/lib/apt,sharing=locked \
   /bin/bash -c 'source ${SPACEROS_DIR}/install/setup.bash' \
- && rosdep install --from-paths ../spaceros/src src --ignore-src --rosdistro ${ROS_DISTRO} -r -y --skip-keys "console_bridge generate_parameter_library fastcdr fastrtps rti-connext-dds-5.3.1 urdfdom_headers rmw_connextdds ros_testing rmw_connextdds rmw_fastrtps_cpp rmw_fastrtps_dynamic_cpp composition demo_nodes_py lifecycle rosidl_typesupport_fastrtps_cpp rosidl_typesupport_fastrtps_c ikos diagnostic_aggregator diagnostic_updater joy qt_gui rqt_gui rqt_gui_py"
+ && rosdep install --from-paths src --ignore-src --rosdistro ${ROS_DISTRO} -r -y --skip-keys "console_bridge generate_parameter_library fastcdr fastrtps rti-connext-dds-5.3.1 urdfdom_headers rmw_connextdds ros_testing rmw_connextdds rmw_fastrtps_cpp rmw_fastrtps_dynamic_cpp composition demo_nodes_py lifecycle rosidl_typesupport_fastrtps_cpp rosidl_typesupport_fastrtps_c ikos diagnostic_aggregator diagnostic_updater joy qt_gui rqt_gui rqt_gui_py"
 
 # Apply a patch to octomap_msgs to work around a build issue
 COPY --chown=${USERNAME}:${USERNAME} octomap_fix.diff ./src/octomap_msgs

--- a/moveit2/README.md
+++ b/moveit2/README.md
@@ -11,6 +11,14 @@ To build the docker image, run:
 ./build.sh
 ```
 
+By default, this will build on top of the latest released version of the Space ROS base image (typically `osrf/space-ros:latest`).
+If building locally, the underlying base image can be set in the [build script](./build.sh), or through the environment with:
+
+```bash
+# Use a locally built image as the base
+SPACE_ROS_IMAGE="space-ros:main" ./build.sh
+```
+
 The build process will take about 30 minutes, depending on the host computer.
 
 ## Running the MoveIt2 Docker Image in a Container

--- a/moveit2/build.sh
+++ b/moveit2/build.sh
@@ -16,7 +16,9 @@ echo ""
 
 docker build -t $ORG/$IMAGE:$TAG \
     --build-arg VCS_REF="$VCS_REF" \
-    --build-arg VERSION="$VERSION" .
+    --build-arg VERSION="$VERSION" \
+    --build-arg SPACE_ROS_IMAGE="${SPACE_ROS_IMAGE:-osrf/space-ros:latest}" \
+    .
 
 echo ""
 echo "##### Done! #####"

--- a/navigation2/Dockerfile
+++ b/navigation2/Dockerfile
@@ -16,10 +16,13 @@
 #
 # The script provides the following build arguments:
 #
-#   VCS_REF     - The git revision of the Space ROS source code (no default value).
-#   VERSION     - The version of Space ROS (default: "preview")
+#   VCS_REF         - The git revision of the Space ROS source code (no default value).
+#   VERSION         - The version of Space ROS (default: "preview")
+#   SPACE_ROS_IMAGE - The base Space ROS image to build on
 
-FROM osrf/space-ros:latest
+ARG SPACE_ROS_IMAGE=osrf/space-ros:latest
+
+FROM ${SPACE_ROS_IMAGE}
 
 # Define arguments used in the metadata definition
 ARG VCS_REF

--- a/navigation2/Dockerfile
+++ b/navigation2/Dockerfile
@@ -62,7 +62,7 @@ RUN mkdir ${SPACEROS_DIR}/src \
 
 # Generate repos file for nav2 dependencies, exclude packages from Space ROS src
 RUN rosinstall_generator \
-  --rosdistro ${ROSDISTRO} \
+  --rosdistro ${ROS_DISTRO} \
   --deps \
   --exclude-path ${SPACEROS_DIR}/src -- \
   -- $(cat ${NAVIGATION2_WS}/nav2_dep_keys.txt) \

--- a/navigation2/README.md
+++ b/navigation2/README.md
@@ -12,6 +12,14 @@ To build the docker image, run:
 
 The build process will take about 30 minutes, depending on the host computer.
 
+By default, this will build on top of the latest released version of the Space ROS base image (typically `osrf/space-ros:latest`).
+If building locally, the underlying base image can be set in the [build script](./build.sh), or through the environment with:
+
+```bash
+# Use a locally built image as the base
+SPACE_ROS_IMAGE="space-ros:main" ./build.sh
+```
+
 ## Running the Navigation2 Docker Image in a Container
 
 After building the image, you can see the newly-built image by running:

--- a/navigation2/build.sh
+++ b/navigation2/build.sh
@@ -16,7 +16,9 @@ echo ""
 
 docker build -t $ORG/$IMAGE:$TAG \
     --build-arg VCS_REF="$VCS_REF" \
-    --build-arg VERSION="$VERSION" .
+    --build-arg VERSION="$VERSION" \
+    --build-arg SPACE_ROS_IMAGE="${SPACE_ROS_IMAGE:-osrf/space-ros:latest}" \
+    .
 
 echo ""
 echo "##### Done! #####"

--- a/space_robots/Dockerfile
+++ b/space_robots/Dockerfile
@@ -56,7 +56,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 # COPY --chown=${USERNAME}:${USERNAME} demo-pkgs.txt /tmp/
 # COPY --chown=${USERNAME}:${USERNAME} excluded-pkgs.txt /tmp/
 # RUN rosinstall_generator \
-#   --rosdistro ${ROSDISTRO} \
+#   --rosdistro ${ROS_DISTRO} \
 #   --deps \
 #   --exclude-path ${SPACEROS_DIR}/src \
 #   --exclude-path ${MOVEIT2_DIR}/src \
@@ -91,7 +91,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   sudo apt-get update -y \
 && /bin/bash -c 'source "${SPACEROS_DIR}/install/setup.bash"' \
 && /bin/bash -c 'source "${MOVEIT2_DIR}/install/setup.bash"' \
-&& rosdep install --from-paths src --ignore-src -r -y --rosdistro ${ROSDISTRO}
+&& rosdep install --from-paths src --ignore-src -r -y --rosdistro ${ROS_DISTRO}
 
 # Build the demo
 RUN /bin/bash -c 'source ${SPACEROS_DIR}/install/setup.bash && source ${MOVEIT2_DIR}/install/setup.bash \

--- a/space_robots/README.md
+++ b/space_robots/README.md
@@ -57,7 +57,7 @@ docker exec -it <container-name> bash
 Make sure packages are sourced:
 
 ```bash
-source ~/spaceros/install/setup.bash
+source ${SPACEROS_DIR}/install/setup.bash
 ```
 
 ```bash


### PR DESCRIPTION
Resolves #161.

There are still issues building `main` for moveit and nav2 after migration of the base image build to the space-ros repo. This PR fixes them, including

* Updating changed environment variable names
* Fixes references to moved or removed directories in the base image
* Parameterizes the base image name for building locally and in CI

As the base `main` image is now pushed to GHCR, we should use that when building in CI. The change can be tested locally if you have access to the container registry (you _must_ be logged in):

Update:

Depends on https://github.com/space-ros/space-ros/pull/220

Because the GHCR images are not public, we can temporarily point to the main branch in the docker registry. This can be tested with either `moveit2` or `nav2` with:

```
$ docker pull osrf/space-ros:main
$ SPACE_ROS_IMAGE=osrf/space-ros:main ./build.sh
```


