### PR TITLE
Racs2 demo

### DIFF
--- a/racs2_demos_on_spaceros/Dockerfile
+++ b/racs2_demos_on_spaceros/Dockerfile
@@ -1,0 +1,124 @@
+# Copyright 2021 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# A Docker configuration script to build the Space ROS image.
+#
+# The script provides the following build arguments:
+#
+#   VCS_REF     - The git revision of the Space ROS source code (no default value).
+#   VERSION     - The version of Space ROS (default: "preview")
+
+FROM openrobotics/space_robots_demo:latest
+
+# Define arguments used in the metadata definition
+ARG VCS_REF
+ARG VERSION="preview"
+
+# Specify the docker image metadata
+LABEL org.label-schema.schema-version="1.0"
+LABEL org.label-schema.name="RACS2 demo on Curiosity Rover"
+LABEL org.label-schema.description="RACS2 demo on the Space ROS platform"
+LABEL org.label-schema.vendor="JAXA"
+LABEL org.label-schema.version=${VERSION}
+LABEL org.label-schema.url="https://github.com/space-ros"
+LABEL org.label-schema.vcs-url="https://github.com/space-ros/docker"
+LABEL org.label-schema.vcs-ref=${VCS_REF}
+
+# Define a few key variables
+ENV RACS2_DEMO_DIR=${HOME_DIR}/racs2_ws
+
+# Disable prompting during package installation
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Get rosinstall_generator
+# Using Docker BuildKit cache mounts for /var/cache/apt and /var/lib/apt ensures that
+# the cache won't make it into the built image but will be maintained between steps.
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  --mount=type=cache,target=/var/lib/apt,sharing=locked \
+  sudo apt-get update -y && sudo apt-get install -y python3-rosinstall-generator
+
+RUN mkdir -p ${RACS2_DEMO_DIR}
+WORKDIR ${RACS2_DEMO_DIR}
+
+# Install dependencies
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  --mount=type=cache,target=/var/lib/apt,sharing=locked \
+  sudo apt-get install libwebsockets-dev libwebsockets-dev protobuf-c-compiler libprotobuf-c-dev python3-pip tmux gdb -y
+RUN python3 -m pip install protobuf==3.20.0 websockets
+
+# Get the cFS source code
+RUN git clone --recursive -b v6.7.0a https://github.com/nasa/cFS/ cfs
+WORKDIR ${RACS2_DEMO_DIR}/cfs
+RUN git submodule init
+RUN git submodule update
+
+# Get the RACS2 source code
+WORKDIR ${RACS2_DEMO_DIR}
+RUN git clone https://github.com/jaxa/racs2_bridge
+
+# Get the demo source code
+# rename old demo directory and exclude from build
+WORKDIR ${DEMO_DIR}/src
+RUN mv demos demos_old
+RUN touch demos_old/COLCON_IGNORE
+# git clone new demo
+RUN git clone https://github.com/tt-saito/demos.git -b racs2_demo
+
+# Customize cFS to run the bridge
+WORKDIR ${RACS2_DEMO_DIR}/cfs
+RUN cp cfe/cmake/Makefile.sample Makefile
+RUN cp -r cfe/cmake/sample_defs sample_defs
+RUN cp -pr ${RACS2_DEMO_DIR}/racs2_bridge/cFS/Bridge/Client_C/apps/racs2_bridge_client apps/
+
+# Deploy the run_app application and adjust the startup scripts
+RUN cp -pr ${DEMO_DIR}/src/demos/mars_rover/cFS/sample_defs/* ${RACS2_DEMO_DIR}/cfs/sample_defs/
+RUN cp -pr ${DEMO_DIR}/src/demos/mars_rover/cFS/apps/run_app ${RACS2_DEMO_DIR}/cfs/apps/
+
+# This is necessary to run cFS inside docker
+RUN sed -i -e 's/^#undef OSAL_DEBUG_PERMISSIVE_MODE/#define OSAL_DEBUG_PERMISSIVE_MODE 1/g' sample_defs/default_osconfig.h
+RUN sed -i -e 's/^#undef OSAL_DEBUG_DISABLE_TASK_PRIORITIES/#define OSAL_DEBUG_DISABLE_TASK_PRIORITIES 1/g' sample_defs/default_osconfig.h
+
+# This is only needed because docker by default starts in IPv4. This setting
+# is specific to the JAXA bridge.
+RUN sed -i -e 's/^wss_uri=.*/wss_uri=127.0.0.1/g' sample_defs/racs2_bridge_config.txt
+
+# Compile cFS
+RUN make SIMULATION=native prep
+RUN make
+RUN make install
+
+# Prepare ROS packages
+WORKDIR ${DEMO_DIR}
+# Copy bridge & racs2_msg node
+RUN cp -pr ${RACS2_DEMO_DIR}/racs2_bridge/ROS2/Bridge/Server_Python/bridge_py_s src/
+RUN cp -pr ${RACS2_DEMO_DIR}/racs2_bridge/Example/Case.1/ROS2/racs2_msg src/
+# Install dependencies
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  --mount=type=cache,target=/var/lib/apt,sharing=locked \
+  sudo apt-get update -y \
+&& /bin/bash -c 'source "${SPACEROS_DIR}/install/setup.bash"' \
+&& /bin/bash -c 'source "${MOVEIT2_DIR}/install/setup.bash"' \
+&& rosdep install --from-paths src --ignore-src -r -y --rosdistro ${ROSDISTRO}
+
+# Build the demo
+RUN /bin/bash -c 'source ${SPACEROS_DIR}/install/setup.bash && source ${MOVEIT2_DIR}/install/setup.bash \
+  && colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release'
+
+# Add the user to the render group so that the user can access /dev/dri/renderD128
+RUN sudo usermod -aG render $USERNAME
+
+# Setup the entrypoint
+COPY ./entrypoint.sh /
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["bash"]

--- a/racs2_demos_on_spaceros/README.md
+++ b/racs2_demos_on_spaceros/README.md
@@ -79,6 +79,9 @@ Drive commands to the rover are input via keyboard. The keymap is as follows.
 * "d": Turn right
 * "x": Stop the rover
 
+#### Nodes in Demo 
+<img width="899" alt="racs2_demo_on_spaceros_nodes" src="https://github.com/user-attachments/assets/77bfdc70-4a5f-4124-a526-ba746db44ec3" />
+
 ## Reference
 
 * [Hiroki Kato, et al. "ROS and cFS System (RACS): Easing Space Robotic Development post-opensource activities and ROS2 integration" Flight Software Workshop 2021.](https://drive.google.com/file/d/11L48doT_pRNs7R0hdChPALqJO849TvV2/view?usp=drive_web)

--- a/racs2_demos_on_spaceros/README.md
+++ b/racs2_demos_on_spaceros/README.md
@@ -1,0 +1,84 @@
+# RACS2 on Space ROS and Space Robots Demo Docker Image
+
+The RACS2 on Space ROS and Space Robots Demo docker image uses the space_robots demo docker image (*openrobotics/space_robots_demo:latest*) as its base image.
+Build instructions for that image can be found in [this README](../space_robots/README.md).
+The Dockerfile installs all of the prerequisite system dependencies along with the demos source code, then builds the Space ROS Space Robots and [RACS2](https://github.com/jaxa/racs2_bridge) demo.
+
+
+This is RACS2 Bridge demo for Curiosity Mars rover.
+
+## Building the Demo Docker
+
+The demo image builds on top of the `spaceros`, `moveit2`, `space_robots` images.
+To build the docker image, first ensure the `spaceros` base image is available either by [building it locally](https://github.com/space-ros/space-ros) or pulling it.
+
+Then build the `moveit2`, `space_robots` and `racs2_demos_on_spaceros` demo images: 
+
+```bash
+cd ../moveit2
+./build.sh
+cd ../space_robots
+./build.sh
+cd ../racs2_demos_on_spaceros
+./build.sh
+```
+
+## Running the Demo Docker
+
+run the following to allow GUI passthrough:
+```bash
+xhost +local:docker
+```
+
+Then run:
+```bash
+./run.sh
+```
+
+Depending on the host computer, you might need to remove the ```--gpus all``` flag in ```run.sh```, which uses your GPUs.
+
+## Running the Demos
+
+### Curiosity Mars rover demo
+Launch the rover demo:
+```bash
+ros2 launch mars_rover mars_rover.launch.py
+```
+
+#### RACS2 Bridge demo
+
+##### Running racs2 bridge node
+Open a new terminal and attach to the currently running container:
+
+```bash
+docker exec -it <container-name> bash
+source install/setup.bash
+ros2 run bridge_py_s bridge_py_s_node  --ros-args --params-file ./src/bridge_py_s/config/params.yaml
+```
+
+##### Running cFS bridge app & run_app app
+Open a new terminal and attach to the currently running container:
+
+```bash
+docker exec -it <container-name> bash
+cd ~/racs2_ws
+cd cfs/build/exe/cpu1/
+./core-cpu1
+```
+
+**Executing commands to the rover must be done with this terminal active.**
+
+
+#### Available Commands
+
+Drive commands to the rover are input via keyboard. The keymap is as follows.
+
+* "w": Drive the rover forward
+* "s": Drive the rover backward
+* "a": Turn left
+* "d": Turn right
+* "x": Stop the rover
+
+## Reference
+
+* [Hiroki Kato, et al. "ROS and cFS System (RACS): Easing Space Robotic Development post-opensource activities and ROS2 integration" Flight Software Workshop 2021.](https://drive.google.com/file/d/11L48doT_pRNs7R0hdChPALqJO849TvV2/view?usp=drive_web)

--- a/racs2_demos_on_spaceros/build.sh
+++ b/racs2_demos_on_spaceros/build.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+ORG=jaxa
+IMAGE=racs2_demos_on_spaceros
+TAG=latest
+
+VCS_REF=""
+VERSION=preview
+
+# Exit script with failure if build fails
+set -eo pipefail
+
+echo ""
+echo "##### Building RACS2 Demo on Space ROS Docker Image #####"
+echo ""
+
+docker build -t $ORG/$IMAGE:$TAG \
+    --build-arg VCS_REF="$VCS_REF" \
+    --build-arg VERSION="$VERSION" .
+
+echo ""
+echo "##### Done! #####"
+

--- a/racs2_demos_on_spaceros/entrypoint.sh
+++ b/racs2_demos_on_spaceros/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+# Setup the Demo environment
+source "${DEMO_DIR}/install/setup.bash"
+exec "$@"

--- a/racs2_demos_on_spaceros/run.sh
+++ b/racs2_demos_on_spaceros/run.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# Runs a docker container with the image created by build.bash
+# Requires:
+#   docker
+#   an X server
+
+IMG_NAME=jaxa/racs2_demos_on_spaceros
+
+# Replace `/` with `_` to comply with docker container naming
+# And append `_runtime`
+CONTAINER_NAME="$(tr '/' '_' <<< "$IMG_NAME")"
+
+# Start the container
+docker run --rm -it --name $CONTAINER_NAME  --network host \
+    -e DISPLAY -e TERM   -e QT_X11_NO_MITSHM=1 $IMG_NAME


### PR DESCRIPTION
JAXA's RACS2 Demo integration to the Space ROS project

We would like the space ros project to do these:
1. In "demo" repository, creating a new branch for racs2_demo and modifying mars_rover directory in the branch
2. In "docker" repository, adding "racs2_demos_on_spaceros" directory in main branch

Issue: Create demo of JAXA bridge #26 in demos 

