### PR TITLE
Use apt install for pytest and flake8 testing libraries (fixes #213)

### DIFF
--- a/moveit2/Dockerfile
+++ b/moveit2/Dockerfile
@@ -68,29 +68,26 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   cmake \
   git \
   libbullet-dev \
+  python3-argcomplete \
   python3-colcon-common-extensions \
   python3-flake8 \
+  python3-flake8-blind-except \
+  python3-flake8-builtins \
+  python3-flake8-class-newline \
+  python3-flake8-comprehensions \
+  python3-flake8-deprecated \
+  python3-flake8-docstrings \
+  python3-flake8-import-order \
+  python3-flake8-quotes \
   python3-pip \
+  python3-pytest \
   python3-pytest-cov \
+  python3-pytest-repeat \
+  python3-pytest-rerunfailures \
   python3-rosdep \
   python3-setuptools \
   python3-vcstool \
   wget
-
-# Install some pip packages needed for testing
-RUN python3 -m pip install -U \
-  argcomplete \
-  flake8-blind-except \
-  flake8-builtins \
-  flake8-class-newline \
-  flake8-comprehensions \
-  flake8-deprecated \
-  flake8-docstrings \
-  flake8-import-order \
-  flake8-quotes \
-  pytest-repeat \
-  pytest-rerunfailures \
-  pytest
 
 # Get the MoveIt2 source code
 WORKDIR ${HOME_DIR}


### PR DESCRIPTION
Fixes build failure of moveit2 images on Ubuntu 24.04 base images.

We luck out here, everything we need is in the apt repos, but we should revisit where these dependencies come from and why they are being installed this way.