### PR TITLE
Allow customizing MoveIt2 docker image tag

### DIFF
--- a/moveit2/README.md
+++ b/moveit2/README.md
@@ -19,6 +19,14 @@ If building locally, the underlying base image can be set in the [build script](
 SPACE_ROS_IMAGE="space-ros:main" ./build.sh
 ```
 
+Similarly, the tag for the resulting Docker image can be customized using the `MOVEIT2_TAG` environment variable.
+For example, to build an image based on the `space-ros:humble-2024.10.0` image and tag it with the same release label use:
+
+```bash
+# Use a locally built image as the base
+SPACE_ROS_IMAGE="osrf/space-ros:humble-2024.10.0" MOVEIT2_TAG=humble-2024.10.0 ./build.sh
+```
+
 The build process will take about 30 minutes, depending on the host computer.
 
 ## Running the MoveIt2 Docker Image in a Container

--- a/moveit2/build.sh
+++ b/moveit2/build.sh
@@ -2,7 +2,7 @@
 
 ORG=openrobotics
 IMAGE=moveit2
-TAG=latest
+TAG=${MOVEIT2_TAG:-"latest"}
 
 VCS_REF=""
 VERSION=preview


### PR DESCRIPTION
Currently, the build script for the MoveIt2 image picks `latest` as the tag, which prevents us from easily customizing the tag during the build.
    
This PR adjusts the build script for the MoveIt2 image to pick a tag passed in a variable as `MOVEIT2_TAG`. If the variable is not set, `latest` is used instead, defaulting to the current behavior.

The new feature is documented in the associated README.
