### PR TITLE
Update stacks to jazzy-2026.04.0 (#270)

### DIFF
--- a/moveit2/Dockerfile
+++ b/moveit2/Dockerfile
@@ -20,7 +20,7 @@
 #   VERSION         - The version of Space ROS (default: "preview")
 #   SPACE_ROS_IMAGE - The base Space ROS image to build on
 
-ARG SPACE_ROS_IMAGE=osrf/space-ros:jazzy-2026.01.0
+ARG SPACE_ROS_IMAGE=osrf/space-ros:jazzy-2026.04.0
 
 FROM ${SPACE_ROS_IMAGE}
 

--- a/moveit2/build.sh
+++ b/moveit2/build.sh
@@ -17,7 +17,7 @@ echo ""
 docker build -t $ORG/$IMAGE:$TAG \
     --build-arg VCS_REF="$VCS_REF" \
     --build-arg VERSION="$VERSION" \
-    --build-arg SPACE_ROS_IMAGE="${SPACE_ROS_IMAGE:-osrf/space-ros:jazzy-2026.01.0}" \
+    --build-arg SPACE_ROS_IMAGE="${SPACE_ROS_IMAGE:-osrf/space-ros:jazzy-2026.04.0}" \
     .
 
 echo ""

--- a/navigation2/Dockerfile
+++ b/navigation2/Dockerfile
@@ -20,7 +20,7 @@
 #   VERSION         - The version of Space ROS (default: "preview")
 #   SPACE_ROS_IMAGE - The base Space ROS image to build on
 
-ARG SPACE_ROS_IMAGE=osrf/space-ros:jazzy-2026.01.0
+ARG SPACE_ROS_IMAGE=osrf/space-ros:jazzy-2026.04.0
 
 FROM ${SPACE_ROS_IMAGE}
 

--- a/navigation2/build.sh
+++ b/navigation2/build.sh
@@ -17,7 +17,7 @@ echo ""
 docker build -t $ORG/$IMAGE:$TAG \
     --build-arg VCS_REF="$VCS_REF" \
     --build-arg VERSION="$VERSION" \
-    --build-arg SPACE_ROS_IMAGE="${SPACE_ROS_IMAGE:-osrf/space-ros:jazzy-2026.01.0}" \
+    --build-arg SPACE_ROS_IMAGE="${SPACE_ROS_IMAGE:-osrf/space-ros:jazzy-2026.04.0}" \
     .
 
 echo ""


### PR DESCRIPTION
CI will fail until release tag from https://github.com/space-ros/space-ros is pushed to DockerHub