### PR TITLE
Update stacks to jazzy-2026.07.0 (#276).

### DIFF
--- a/moveit2/Dockerfile
+++ b/moveit2/Dockerfile
@@ -20,7 +20,7 @@
 #   VERSION         - The version of Space ROS (default: "preview")
 #   SPACE_ROS_IMAGE - The base Space ROS image to build on
 
-ARG SPACE_ROS_IMAGE=osrf/space-ros:jazzy-2026.04.0
+ARG SPACE_ROS_IMAGE=osrf/space-ros:jazzy-2026.07.0
 
 FROM ${SPACE_ROS_IMAGE}
 

--- a/moveit2/build.sh
+++ b/moveit2/build.sh
@@ -17,7 +17,7 @@ echo ""
 docker build -t $ORG/$IMAGE:$TAG \
     --build-arg VCS_REF="$VCS_REF" \
     --build-arg VERSION="$VERSION" \
-    --build-arg SPACE_ROS_IMAGE="${SPACE_ROS_IMAGE:-osrf/space-ros:jazzy-2026.04.0}" \
+    --build-arg SPACE_ROS_IMAGE="${SPACE_ROS_IMAGE:-osrf/space-ros:jazzy-2026.07.0}" \
     .
 
 echo ""

--- a/navigation2/Dockerfile
+++ b/navigation2/Dockerfile
@@ -20,7 +20,7 @@
 #   VERSION         - The version of Space ROS (default: "preview")
 #   SPACE_ROS_IMAGE - The base Space ROS image to build on
 
-ARG SPACE_ROS_IMAGE=osrf/space-ros:jazzy-2026.04.0
+ARG SPACE_ROS_IMAGE=osrf/space-ros:jazzy-2026.07.0
 
 FROM ${SPACE_ROS_IMAGE}
 

--- a/navigation2/build.sh
+++ b/navigation2/build.sh
@@ -17,7 +17,7 @@ echo ""
 docker build -t $ORG/$IMAGE:$TAG \
     --build-arg VCS_REF="$VCS_REF" \
     --build-arg VERSION="$VERSION" \
-    --build-arg SPACE_ROS_IMAGE="${SPACE_ROS_IMAGE:-osrf/space-ros:jazzy-2026.04.0}" \
+    --build-arg SPACE_ROS_IMAGE="${SPACE_ROS_IMAGE:-osrf/space-ros:jazzy-2026.07.0}" \
     .
 
 echo ""

--- a/navigation2/navigation2.repos
+++ b/navigation2/navigation2.repos
@@ -2,27 +2,31 @@ repositories:
   angles:
     type: git
     url: https://github.com/ros2-gbp/angles-release.git
-    version: release/jazzy/angles/1.16.0-5
+    version: release/jazzy/angles/1.16.1-1
+  backward_ros:
+    type: git
+    url: https://github.com/ros2-gbp/backward_ros-release.git
+    version: release/jazzy/backward_ros/1.0.8-1
   behaviortree_cpp:
     type: git
     url: https://github.com/ros2-gbp/behaviortree_cpp_v4-release.git
-    version: release/jazzy/behaviortree_cpp/4.6.2-1
+    version: release/jazzy/behaviortree_cpp/4.9.1-1
   bond_core/bond:
     type: git
     url: https://github.com/ros2-gbp/bond_core-release.git
-    version: release/jazzy/bond/4.1.2-1
+    version: release/jazzy/bond/4.2.0-1
   bond_core/bondcpp:
     type: git
     url: https://github.com/ros2-gbp/bond_core-release.git
-    version: release/jazzy/bondcpp/4.1.2-1
+    version: release/jazzy/bondcpp/4.2.0-1
   bond_core/smclib:
     type: git
     url: https://github.com/ros2-gbp/bond_core-release.git
-    version: release/jazzy/smclib/4.1.2-1
+    version: release/jazzy/smclib/4.2.0-1
   diagnostics/diagnostic_updater:
     type: git
     url: https://github.com/ros2-gbp/diagnostics-release.git
-    version: release/jazzy/diagnostic_updater/4.2.3-1
+    version: release/jazzy/diagnostic_updater/4.2.7-1
   geographic_info/geographic_msgs:
     type: git
     url: https://github.com/ros2-gbp/geographic_info-release.git
@@ -30,11 +34,11 @@ repositories:
   image_common/image_transport:
     type: git
     url: https://github.com/ros2-gbp/image_common-release.git
-    version: release/jazzy/image_transport/5.1.6-1
+    version: release/jazzy/image_transport/5.1.8-1
   laser_geometry:
     type: git
     url: https://github.com/ros2-gbp/laser_geometry-release.git
-    version: release/jazzy/laser_geometry/2.7.0-3
+    version: release/jazzy/laser_geometry/2.7.2-1
   map_msgs:
     type: git
     url: https://github.com/ros2-gbp/navigation_msgs-release.git
@@ -42,167 +46,171 @@ repositories:
   navigation2/costmap_queue:
     type: git
     url: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/costmap_queue/1.3.5-1
+    version: release/jazzy/costmap_queue/1.3.12-1
   navigation2/dwb_core:
     type: git
     url: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/dwb_core/1.3.5-1
+    version: release/jazzy/dwb_core/1.3.12-1
   navigation2/dwb_critics:
     type: git
     url: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/dwb_critics/1.3.5-1
+    version: release/jazzy/dwb_critics/1.3.12-1
   navigation2/dwb_msgs:
     type: git
     url: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/dwb_msgs/1.3.5-1
+    version: release/jazzy/dwb_msgs/1.3.12-1
   navigation2/dwb_plugins:
     type: git
     url: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/dwb_plugins/1.3.5-1
+    version: release/jazzy/dwb_plugins/1.3.12-1
   navigation2/nav2_amcl:
     type: git
     url: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_amcl/1.3.5-1
+    version: release/jazzy/nav2_amcl/1.3.12-1
   navigation2/nav2_behavior_tree:
     type: git
     url: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_behavior_tree/1.3.5-1
+    version: release/jazzy/nav2_behavior_tree/1.3.12-1
   navigation2/nav2_behaviors:
     type: git
     url: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_behaviors/1.3.5-1
+    version: release/jazzy/nav2_behaviors/1.3.12-1
   navigation2/nav2_bt_navigator:
     type: git
     url: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_bt_navigator/1.3.5-1
+    version: release/jazzy/nav2_bt_navigator/1.3.12-1
   navigation2/nav2_collision_monitor:
     type: git
     url: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_collision_monitor/1.3.5-1
+    version: release/jazzy/nav2_collision_monitor/1.3.12-1
   navigation2/nav2_common:
     type: git
     url: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_common/1.3.5-1
+    version: release/jazzy/nav2_common/1.3.12-1
   navigation2/nav2_constrained_smoother:
     type: git
     url: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_constrained_smoother/1.3.5-1
+    version: release/jazzy/nav2_constrained_smoother/1.3.12-1
   navigation2/nav2_controller:
     type: git
     url: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_controller/1.3.5-1
+    version: release/jazzy/nav2_controller/1.3.12-1
   navigation2/nav2_core:
     type: git
     url: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_core/1.3.5-1
+    version: release/jazzy/nav2_core/1.3.12-1
   navigation2/nav2_costmap_2d:
     type: git
     url: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_costmap_2d/1.3.5-1
+    version: release/jazzy/nav2_costmap_2d/1.3.12-1
   navigation2/nav2_dwb_controller:
     type: git
     url: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_dwb_controller/1.3.5-1
+    version: release/jazzy/nav2_dwb_controller/1.3.12-1
   navigation2/nav2_graceful_controller:
     type: git
     url: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_graceful_controller/1.3.5-1
+    version: release/jazzy/nav2_graceful_controller/1.3.12-1
   navigation2/nav2_lifecycle_manager:
     type: git
     url: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_lifecycle_manager/1.3.5-1
+    version: release/jazzy/nav2_lifecycle_manager/1.3.12-1
   navigation2/nav2_map_server:
     type: git
     url: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_map_server/1.3.5-1
+    version: release/jazzy/nav2_map_server/1.3.12-1
   navigation2/nav2_mppi_controller:
     type: git
     url: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_mppi_controller/1.3.5-1
+    version: release/jazzy/nav2_mppi_controller/1.3.12-1
   navigation2/nav2_msgs:
     type: git
     url: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_msgs/1.3.5-1
+    version: release/jazzy/nav2_msgs/1.3.12-1
   navigation2/nav2_navfn_planner:
     type: git
     url: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_navfn_planner/1.3.5-1
+    version: release/jazzy/nav2_navfn_planner/1.3.12-1
   navigation2/nav2_planner:
     type: git
     url: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_planner/1.3.5-1
+    version: release/jazzy/nav2_planner/1.3.12-1
   navigation2/nav2_regulated_pure_pursuit_controller:
     type: git
     url: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_regulated_pure_pursuit_controller/1.3.5-1
+    version: release/jazzy/nav2_regulated_pure_pursuit_controller/1.3.12-1
   navigation2/nav2_rotation_shim_controller:
     type: git
     url: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_rotation_shim_controller/1.3.5-1
+    version: release/jazzy/nav2_rotation_shim_controller/1.3.12-1
+  navigation2/nav2_route:
+    type: git
+    url: https://github.com/SteveMacenski/navigation2-release.git
+    version: release/jazzy/nav2_route/1.3.12-1
   navigation2/nav2_simple_commander:
     type: git
     url: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_simple_commander/1.3.5-1
+    version: release/jazzy/nav2_simple_commander/1.3.12-1
   navigation2/nav2_smac_planner:
     type: git
     url: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_smac_planner/1.3.5-1
+    version: release/jazzy/nav2_smac_planner/1.3.12-1
   navigation2/nav2_smoother:
     type: git
     url: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_smoother/1.3.5-1
+    version: release/jazzy/nav2_smoother/1.3.12-1
   navigation2/nav2_theta_star_planner:
     type: git
     url: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_theta_star_planner/1.3.5-1
+    version: release/jazzy/nav2_theta_star_planner/1.3.12-1
   navigation2/nav2_util:
     type: git
     url: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_util/1.3.5-1
+    version: release/jazzy/nav2_util/1.3.12-1
   navigation2/nav2_velocity_smoother:
     type: git
     url: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_velocity_smoother/1.3.5-1
+    version: release/jazzy/nav2_velocity_smoother/1.3.12-1
   navigation2/nav2_voxel_grid:
     type: git
     url: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_voxel_grid/1.3.5-1
+    version: release/jazzy/nav2_voxel_grid/1.3.12-1
   navigation2/nav2_waypoint_follower:
     type: git
     url: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav2_waypoint_follower/1.3.5-1
+    version: release/jazzy/nav2_waypoint_follower/1.3.12-1
   navigation2/nav_2d_msgs:
     type: git
     url: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav_2d_msgs/1.3.5-1
+    version: release/jazzy/nav_2d_msgs/1.3.12-1
   navigation2/nav_2d_utils:
     type: git
     url: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/nav_2d_utils/1.3.5-1
+    version: release/jazzy/nav_2d_utils/1.3.12-1
   navigation2/navigation2:
     type: git
     url: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/navigation2/1.3.5-1
+    version: release/jazzy/navigation2/1.3.12-1
   navigation2/opennav_docking:
     type: git
     url: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/opennav_docking/1.3.5-1
+    version: release/jazzy/opennav_docking/1.3.12-1
   navigation2/opennav_docking_bt:
     type: git
     url: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/opennav_docking_bt/1.3.5-1
+    version: release/jazzy/opennav_docking_bt/1.3.12-1
   navigation2/opennav_docking_core:
     type: git
     url: https://github.com/SteveMacenski/navigation2-release.git
-    version: release/jazzy/opennav_docking_core/1.3.5-1
+    version: release/jazzy/opennav_docking_core/1.3.12-1
   ompl:
     type: git
     url: https://github.com/ros2-gbp/ompl-release.git
-    version: release/jazzy/ompl/1.6.0-1
+    version: release/jazzy/ompl/1.7.0-2
   robot_localization:
     type: git
     url: https://github.com/ros2-gbp/robot_localization-release.git
-    version: release/jazzy/robot_localization/3.8.2-1
+    version: release/jazzy/robot_localization/3.8.3-1
   vision_opencv/cv_bridge:
     type: git
     url: https://github.com/ros2-gbp/vision_opencv-release.git
@@ -211,4 +219,3 @@ repositories:
     type: git
     url: https://github.com/ros2-gbp/yaml_cpp_vendor-release.git
     version: release/jazzy/yaml_cpp_vendor/9.0.1-1
-

--- a/navigation2/update_nav2_repos.sh
+++ b/navigation2/update_nav2_repos.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source $SPACEROS_DIR/install/setup.bash
+source $SPACEROS_DIR/setup.bash
 SCRIPT_PATH="$SPACEROS_DIR/scripts"
 bash $SCRIPT_PATH/generate-repos.sh \
     --rosdistro $ROS_DISTRO \


### PR DESCRIPTION
Update all docker images that point to Space ROS jazzy-2026.04.0 to point to Space ROS jazzy-2026.07.0.

Fixes #276.